### PR TITLE
Update theories.tex

### DIFF
--- a/first-order-logic/models-theories/theories.tex
+++ b/first-order-logic/models-theories/theories.tex
@@ -49,7 +49,7 @@ sentences in the language of arithmetic~$\Lang L_A$.
 & \lforall[x][\eq[(x \times \Obj 0)][\Obj 0]]\\
 & \lforall[x][\lforall[y][\eq[(x \times y')][((x \times y) + x)]]]\\
 \intertext{plus all sentences of the form}
-& (!A(\Obj 0) \land \lforall[x][(!A(x) \lif !A(x'))]) \lif \lforall[x][A(x)]
+& (!A(\Obj 0) \land \lforall[x][(!A(x) \lif !A(x'))]) \lif \lforall[x][!A(x)]
 \end{align*}
 Since there are infinitely many sentences of the latter form, this
 axiom system is infinite.  The latter form is called the


### PR DESCRIPTION
Fixing a small typo (might want to make sure that the macro isn't messed up).

Currently views as \phi(0) and \x (\phi(x) -> \phi(x')) -> \x A(x).