### PR TITLE
Fixing typos and adding notes about proofs

### DIFF
--- a/computability/recursive-functions/bounded-minimization.tex
+++ b/computability/recursive-functions/bounded-minimization.tex
@@ -26,7 +26,7 @@ there is no $x < y$ at all.  So $m_R(x, 0) = 0$.
 
 In case the bound is $y + 1$ we have three cases: (a) There is an $x <
 y$ such that $R(x, \vec{z})$, in which case $m_R(y+1, \vec{z}) =
-m_R(y, \vec{z})$. (b) There is no such~$x$ but $R(y, \vec{z})$, then
+m_R(y, \vec{z})$. (b) There is no such~$x$ but $R(y, \vec{z})$ holds, then
 $m_R(y+1, \vec{z}) = y$. (c) There is no $x < y+1$ such that $R(x,
 \vec{z})$, then $m_R(y+1,\vec{z}) = 0$. So,
 \begin{align*}

--- a/computability/recursive-functions/halting-problem.tex
+++ b/computability/recursive-functions/halting-problem.tex
@@ -11,7 +11,7 @@
 
 The \emph{halting problem} in general is the problem of deciding,
 given the specification~$e$ (e.g., program) of a computable function
-and a number~$n$, whether the computation of the function on input~$e$
+and a number~$n$, whether the computation of the function on input~$n$
 halts, i.e., produces a result.  Famously, Alan Turing proved that
 this problem itself cannot be solved by a computable function, i.e.,
 the function

--- a/computability/recursive-functions/halting-problem.tex
+++ b/computability/recursive-functions/halting-problem.tex
@@ -74,11 +74,11 @@ $e_d$. Consider the value of $h(e_d, e_d)$. There are two
 possible cases, 0 and 1.
 \begin{enumerate}
 \item If $h(e_d, e_d) = 1$ then $\cfind{e_d}(e_d) \defined$.  But
-  $\cfind{e_d} = d$, and $d(e_d)$ is defined iff $h(e_d, e_d) = 0$.
+  $\cfind{e_d} \simeq d$, and $d(e_d)$ is defined iff $h(e_d, e_d) = 0$.
   So $h(e_d, e_d) \neq 1$.
 \item If $h(e_d, e_d) = 0$ then either $e_d$ is not the index of a
   partial recursive function, or it is and $\cfind{e_d}(e_d)
-  \undefined$. But again, $\cfind{e_d} = d$, and $d(e_d)$ is undefined
+  \undefined$. But again, $\cfind{e_d} \simeq d$, and $d(e_d)$ is undefined
   iff $\cfind{e_d}(e_d) \defined$.
 \end{enumerate}
 The upshot is that $e_d$ cannot, after all, be the index of a partial

--- a/computability/recursive-functions/non-pr-functions.tex
+++ b/computability/recursive-functions/non-pr-functions.tex
@@ -42,7 +42,7 @@ roughly like an exponential stack of $x$ $2$'s. Ackermann's function is
 essentially the function $G(x) = g_x(x)$, and one can show that this
 grows faster than any primitive recursive function.
 
-Let use return to the issue of enumerating the primitive recursive
+Let us return to the issue of enumerating the primitive recursive
 functions. Remember that we have assigned symbolic notations to each
 primitive recursive function; so it suffices to enumerate
 notations. We can assign a natural number $\#(F)$ to each notation $F$,

--- a/computability/recursive-functions/normal-form.tex
+++ b/computability/recursive-functions/normal-form.tex
@@ -11,7 +11,7 @@
 
 \begin{thm}[Kleene's Normal Form Theorem]
 \ollabel{thm:kleene-nf}
-There are a primitive recursive relation $T(e, x, s)$ and a primitive
+There is a primitive recursive relation $T(e, x, s)$ and a primitive
 recursive function $U(s)$, with the following property: if $f$ is any
 partial recursive function, then for some~$e$,
 \[

--- a/computability/recursive-functions/partial-functions.tex
+++ b/computability/recursive-functions/partial-functions.tex
@@ -23,7 +23,7 @@ cannot be exhaustive!
 
 The way out is to allow \emph{partial} functions to come into play. We
 will see that it \emph{is} possible to enumerate the partial
-computable functions.\iftag{TMs}{in fact, we already pretty much know
+computable functions.\iftag{TMs}{ In fact, we already pretty much know
   that this is the case, since it is possible to enumerate Turing
   machines in a systematic way.}{} We will come back to our diagonal
 argument later, and explore why it does not go through when partial
@@ -48,7 +48,7 @@ are partial functions, we will write $f(x) \defined$ to mean that $f$
 is defined at $x$, i.e., $x$ is in the domain of $f$; and $f(x)
 \undefined$ to mean the opposite, i.e., that $f$ is not defined at~$x$.
 We will use $f(x) \simeq g(x)$ to mean that either $f(x)$ and $g(x)$
-are both undefined, or they are both defined and equal. We will these
+are both undefined, or they are both defined and equal. We will use these
 notations for more complicated terms as well. We will adopt the
 convention that if $h$ and $g_0$, \dots,~$g_k$ all are partial functions,
 then

--- a/computability/recursive-functions/sequences.tex
+++ b/computability/recursive-functions/sequences.tex
@@ -12,7 +12,7 @@
 The set of primitive recursive functions is
 remarkably robust. But we will be able to do even more once we have
 developed an adequate means of handling \emph{sequences}.  We will
-identify finite sequences of natural numbers with natural numbers, in
+identify finite sequences of natural numbers with natural numbers in
 the following way: the sequence $\langle a_0, a_1, a_2, \dots, a_k \rangle$
 corresponds to the number
 \[
@@ -67,7 +67,7 @@ $\fn{append}(\fn{append}(\dots \fn{append}(\emptyseq,s_0)
 $(s)_0$, \dots,~$(s)_{k-1}$.
 
 It will be useful for us to be able to bound the numeric code of a
-sequence, in terms of its length and its largest element. Suppose $s$
+sequence in terms of its length and its largest element. Suppose $s$
 is a sequence of length $k$, each element of which is less than equal
 to some number $x$. Then $s$ has at most $k$ prime factors, each at
 most $p_{k-1}$, and each raised to at most $x+1$ in the prime
@@ -75,7 +75,7 @@ factorization of $s$. In other words, if we define
 \[
 \fn{sequenceBound}(x,k) = p_{k-1}^{k \cdot (x+1)},
 \]
-then the numeric code of the sequence~$s$ described above, is at
+then the numeric code of the sequence~$s$ described above is at
 most~$\fn{sequenceBound}(x,k)$.
 
 Having such a bound on sequences gives us a way of defining new

--- a/incompleteness/arithmetization-syntax/coding-formulas.tex
+++ b/incompleteness/arithmetization-syntax/coding-formulas.tex
@@ -24,6 +24,7 @@ x = \Gn{\Obj P^n_j(} \concat \fn{flatten}(z) \concat \Gn{)} \text{, or}
 \]
 \item there are $z_1, z_2 < x$ such that $x = z_1 \concat \Gn{\eq}
   \concat \eq z_2$ and $\fn{Term}(z_1)$ and $\fn{Term}(z_2)$.
+% Missing the case for bottom
 \end{enumerate}
 \end{proof}
 

--- a/incompleteness/arithmetization-syntax/coding-symbols.tex
+++ b/incompleteness/arithmetization-syntax/coding-symbols.tex
@@ -64,7 +64,7 @@ The following relations are primitive recursive:
 \end{prop}
 
 \begin{defn}
-If $\tuple{s_0, \dots, s_n}$ is a sequence of symbols, its
+If $s_0, \dots, s_n$ is a sequence of symbols, its
 \emph{G\"odel number} is $\tuple{\scode{s_0}, \dots, \scode{s_n}}$.
 \end{defn}
 

--- a/incompleteness/arithmetization-syntax/coding-symbols.tex
+++ b/incompleteness/arithmetization-syntax/coding-symbols.tex
@@ -44,6 +44,7 @@ defined as follows:
 \item If $s$ is the $i$-th variable $\Obj x_i$, then $\scode s = \tuple{1, i}$.
 \item If $s$ is the $i$-th $n$-ary !!{constant}~$\Obj c_i^n$, then
   $\scode s = \tuple{2, n, i}$.
+% n-ary constant symbols?
 \item If $s$ is the $i$-th $n$-ary !!{function}~$\Obj f_i^n$, then
   $\scode s = \tuple{3, n, i}$.
 \item If $s$ is the $i$-th $n$-ary !!{predicate}~$\Obj P_i^n$, then

--- a/incompleteness/arithmetization-syntax/coding-terms.tex
+++ b/incompleteness/arithmetization-syntax/coding-terms.tex
@@ -35,7 +35,7 @@ the formation rules it has to be the case that, for each $i < k$, either
 \item $s_i$ is a variable~$\Obj v_j$, or
 \item $s_i$ is a !!{constant}~$\Obj c_j$, or
 \item $s_i$ is built from $n$ terms $t_1$, \dots, $t_n$ occurring
-  prior to place~$i$ in using an $n$-place function symbol~$\Obj f^n_j$.
+  prior to place~$i$ using an $n$-place function symbol~$\Obj f^n_j$.
 \end{enumerate}
 To show that the corresponding relation on G\"odel numbers is
 primitive recursive, we have to express this condition primitive

--- a/incompleteness/arithmetization-syntax/proofs-in-lk.tex
+++ b/incompleteness/arithmetization-syntax/proofs-in-lk.tex
@@ -41,7 +41,7 @@ $k$: & 7 & 8 & 9 & 10 & 11
   \Gn{\Pi''}}$ if $\Pi$ ends in an inference with two premises, $k$ is
   given by the following table according to which rule was used in the
   last inference, and $\Pi'$, $\Pi''$ are the the immediate subproof
-  ending in the laft and right premise of the last inference,
+  ending in the left and right premise of the last inference,
   respectively.
 
 \begin{tabular}{lcccc}
@@ -80,7 +80,7 @@ For instance, $\Gamma \Sequent \Delta$ follows from $\Gamma' \Sequent
 variable~$x$ and a closed term~$t$ such that $\Gamma = \Gamma'$,
 $\Subst{!A}{t}{x} \in \Delta'$, $\lexists[x][!A] \in \Delta$, and for
 every $!B \in \Delta$, either $!B = \lexists[x][!A]$ or $!B \in
-\Gamma'$.  We just have to translate into G\"odel numbers.  If $s =
+\Delta'$.  We just have to translate into G\"odel numbers.  If $s =
 \Gn{\Gamma \Sequent \Delta}$ then $(s)_0 = \Gn{\Gamma}$ and $(s)_1 =
 \Gn{\Gamma}$. So:
 \begin{align*}

--- a/incompleteness/arithmetization-syntax/substitution.tex
+++ b/incompleteness/arithmetization-syntax/substitution.tex
@@ -10,7 +10,7 @@
 \olsection{Substitution}
 
 \begin{prop}
-There is a primitive recursive function $\fn{Subst}(x, y, z)$ with
+There is a primitive recursive function $\fn{Subst}(x, y, z)$ with the property that
 \[
 \fn{Subst}(\Gn{!A}, \Gn{t}, \Gn{x}) = \Gn{\Subst{!A}{t}{x}}
 \]
@@ -23,6 +23,7 @@ occurrence of the variable with G\"odel number~$z$, is primitive
 recursive.  We can then define a function $\fn{Subst}'$ by primitive
 recursion as follows:
 
+% Also need to ensure that y is free for z in x as well.
 \begin{align*}
 \fn{Subst}'(0, x, y, z) & = \emptyseq \\
 \fn{Subst}'(i + 1, x, y, z) & =

--- a/incompleteness/incompleteness-provability/lob-thm.tex
+++ b/incompleteness/incompleteness-provability/lob-thm.tex
@@ -35,7 +35,7 @@ to substitute any other conclusion you would like.) Here it is:
 \item Let $X$ be the sentence, ``If $X$ is true, then Santa Claus
   exists.''
 \item Suppose $X$ is true.
-\item Then what is says is true; i.e., if $X$ is true, then
+\item Then what it says is true; i.e., if $X$ is true, then
   Santa Claus exists.
 \item Since we are assuming $X$ is true, we can conclude that
   Santa Claus exists.
@@ -68,7 +68,7 @@ following is provable in $\Th{T}$:
 & \OProv[T](\gn{!D}) \lif !A \\
 & !D && \text{def of $!D$} \\
 & \OProv[T](\gn{!D}) && \text{by 1} \\
-& !A \\
+& !A
 \end{align*}
 \end{proof}
 

--- a/incompleteness/incompleteness-provability/provability-conditions.tex
+++ b/incompleteness/incompleteness-provability/provability-conditions.tex
@@ -51,7 +51,7 @@ the formula $\OProv[PA](y)$ carefully and use the axioms of $\Th{PA}$ to
 describe the relevant formal proofs. Clauses 1 and 2 are easy; it is
 really clause 3 that requires work. (Think about what kind of work it
 entails\dots) Carrying out the details would be tedious and
-uninteresting, so here we will ask you to take it on faith the
+uninteresting, so here we will ask you to take it on faith that
 $\Th{PA}$ has the three properties listed above. A reasonable choice
 of $\OProv[PA](y)$ will also satisfy
 \begin{enumerate}
@@ -65,7 +65,7 @@ Incidentally, G\"odel was lazy in the same way we are
 being now. At the end of the 1931 paper, he sketches the proof of the
 second incompleteness theorem, and promises the details in a later
 paper. He never got around to it; since everyone who understood the
-argument believed that it could be carried out, he did not need to
+argument believed that it could be carried out (he did not need to
 fill in the details.)
 \end{digress}
 

--- a/incompleteness/incompleteness-provability/rosser-thm.tex
+++ b/incompleteness/incompleteness-provability/rosser-thm.tex
@@ -11,7 +11,7 @@
 \olsection{Rosser's Theorem}
 
 Can we modify G\"odel's proof to get a stronger result, replacing
-``$\omega$-consistent'' with simply ``consistent''?? The answer is
+``$\omega$-consistent'' with simply ``consistent''? The answer is
 ``yes,'' using a trick discovered by Rosser. Let $\fn{not}(x)$ be the
 primitive recursive function which does the following: if $x$ is the
 code of a formula $!A$, $\fn{not}(x)$ is a code of $\lnot !A$.  To
@@ -48,6 +48,7 @@ doesn't prove $\lnot !R_\Th{T}$. (In other words, we don't need the
 assumption of $\omega$-consistency.)
 
 \begin{digress}
+% This comment doesn't make much sense, what are you trying to get at?
 By comparison to the proof of
 \olref[tcp][inc]{thm:first-incompleteness}, the proofs of
 \olref[1in]{thm:first-incompleteness} and its improvement by Rosser

--- a/incompleteness/incompleteness-provability/tarski-thm.tex
+++ b/incompleteness/incompleteness-provability/tarski-thm.tex
@@ -58,7 +58,7 @@ Let $!D_T$ define $T$ in $\Struct{N}$. Then
 \[
 H = \Setabs{x}{\Sat{N}{\lexists[y][!D_T(\num e, \num x, y)]}},
 \]
-so $\lexists[y][!D_T(\num e, x, y)]$ defines~$H$ is $\Struct{N}$. 
+so $\lexists[y][!D_T(\num e, x, y)]$ defines~$H$ in $\Struct{N}$. 
 \end{proof}
 
 \begin{prob}
@@ -94,7 +94,7 @@ Tarski's oft-quoted example, for English, is the sentence
 `Snow is white' is true if and only if snow is white.
 \end{quote}
 However, for any language strong enough to represent the diagonal
-function, and any linguistic predicate $T(x)$, and can construct a
+function, and any linguistic predicate $T(x)$, we can construct a
 sentence $X$ satisfying ``$X$ if and only if not $T(\text{`$X$'})$.''
 Given that we do not want a truth predicate to declare some sentences
 to be both true and false, Tarski concluded that one cannot specify a

--- a/incompleteness/representability-in-q/beta-function.tex
+++ b/incompleteness/representability-in-q/beta-function.tex
@@ -49,7 +49,7 @@ $a \equiv b \mod c$ means $c \mid (a-b)$, i.e.\ $a$ and $b$ have the
 same remainder when divided by $c$.
 \end{defn}
 
-Here is the \emph{Chinese remainder theorem}:
+Here is the \emph{Chinese Remainder theorem}:
 \begin{thm}
 Suppose $x_0,\dots,x_n$ are (pairwise) relatively prime. Let
 $y_0$, \dots, $y_n$ be any numbers. Then there is a number $z$ such that
@@ -61,7 +61,7 @@ z & \equiv & y_n \mod x_n.
 \end{eqnarray*}
 \end{thm}
 
-Here is how we will use the Chinese remainder theorem: if
+Here is how we will use the Chinese Remainder theorem: if
 $x_0,\dots,x_n$ are bigger than $y_0,\dots,y_n$ respectively, then
 we can take $z$ to code the sequence $\langle y_0,\dots,y_n\rangle$. To recover
 $y_i$, we need only divide $z$ by $x_i$ and take the remainder. To use
@@ -113,13 +113,14 @@ example:
 We can then show that all of the following are in $C$:
 \begin{enumerate}
 \item The pairing function, $J(x,y) = \frac{1}{2}[(x+y)(x+y+1)] + x$
+% maybe explain more what is going on here, a bit confusing.
 \item Projections 
 \[
-K(z) = \mu {x \leq q} \; (\lexists[y \leq z][z = J(x,y)])
+K(z) = \mu {x \leq q} \; (\lexists[y \leq z] \, [z = J(x,y)])
 \]
 and
 \[
-L(z) = \mu {y \leq q} \; (\lexists[x \leq z][z = J(x,y)]).
+L(z) = \mu {y \leq q} \; (\lexists[x \leq z]\, [z = J(x,y)]).
 \]
 \item $x < y$
 \item $x \mid y$
@@ -146,7 +147,7 @@ j = \max(n,a_0,\dots,a_n)+1,
 \]
 and let $d_1 = j\fac$. By the observations above, we know that $1+d_1,
 1+2 d_1, \dots, 1+(n+1) d_1$ are relatively prime and all are bigger
-than $a_0,\dots,a_n$. By the Chinese remainder theorem there is a
+than $a_0,\dots,a_n$. By the Chinese Remainder theorem there is a
 value $d_0$ such that for each $i$,
 \[
 d_0 \equiv a_i \mod (1+(i+1)d_1)
@@ -155,7 +156,7 @@ and so (because $d_1$ is greater than $a_i$),
 \[
 a_i = \fn{rem}(1+(i+1)d_1,d_0).
 \]
-Let $d = J((d)_0,(d)_1)$. Then for each $i$ from $0$ to $n$, we have
+Let $d = J(d_0,d_1)$. Then for each $i$ from $0$ to $n$, we have
 \begin{eqnarray*}
 \beta(d,i) & = & \beta^*(d_0,d_1,i) \\
 & = & \fn{rem}(1+(i+1) d_1,d_0) \\

--- a/incompleteness/representability-in-q/c-representable.tex
+++ b/incompleteness/representability-in-q/c-representable.tex
@@ -49,7 +49,7 @@ $\Th{Q}$ proves $0'' \neq 0'''$. But showing that this holds in general
 requires some care. Note also that although we are using induction, it
 is induction \emph{outside} of $\Th{Q}$.
 
-We will be able to represent zero, successor, plus, times, and the
+We will be able to represent zero, successor, plus, times, the
 characteristic function for equality, and projections. In each case,
 the appropriate representing function is entirely straightforward; for
 example, zero is represented by the formula
@@ -97,7 +97,7 @@ z,y)$. Let $f$ be defined by $f(\vec z) = \mu x \; g(x,\vec z)$. We would
 like to find a formula $!A_f(\vec z,y)$ representing $f$. Here is
 a natural choice:
 \[
-!A_f(\vec z,y) \ident !A_g(y,\vec z,0) \land \lforall[w][(w < z
+!A_f(\vec z,y) \ident !A_g(y,\vec z,0) \land \lforall[w][(w < y
 \lif \lnot !A_g(w,\vec z,0))].
 \]
 

--- a/incompleteness/representability-in-q/c.tex
+++ b/incompleteness/representability-in-q/c.tex
@@ -20,7 +20,7 @@ Let $C$ be the smallest set of functions containing
 \end{enumerate}
 and closed under
 \begin{enumerate}
-\item composition and
+\item composition, and
 \item unbounded search, applied to regular
 functions. 
 \end{enumerate}

--- a/incompleteness/representability-in-q/comp-representable.tex
+++ b/incompleteness/representability-in-q/comp-representable.tex
@@ -10,7 +10,7 @@
 \olsection{Computable Functions are Representable in $\Th{Q}$}
 
 \begin{lem}
-Every computable function is represenatbale in~$\Th{Q}$.
+Every computable function is representable in~$\Th{Q}$.
 \end{lem}
 
 \begin{enumerate}

--- a/incompleteness/representability-in-q/introduction.tex
+++ b/incompleteness/representability-in-q/introduction.tex
@@ -27,6 +27,7 @@ arithmetic; $\Th{Q}$ consists of the following axioms
 (to be used in conjunction with the other axioms and rules of
 first-order logic with !!{identity}):
 \begin{enumerate}
+% Maybe add the quantifiers here.
 \item $x' = y' \lif x = y$
 \item $\eq/[0][x']$
 \item $\eq/[x][0] \lif \lexists[y][\eq[x][y']]$
@@ -47,7 +48,7 @@ so weak, in fact, just barely strong enough for the incompleteness
 theorem to hold; and also because it has a \emph{finite} set of
 axioms.
 
-A stronger theory than $\Th{Q}$ called \emph{Peano arithmetic} $\Th{PA}$, and
+A stronger theory than $\Th{Q}$ called \emph{Peano arithmetic} $\Th{PA}$,
 is obtained by adding a schema of induction to~$\Th{Q}$:
 \[
 (!A(0) \land \lforall[x][(!A(x) \lif !A(x'))]) \lif \lforall[x][!A(x)]
@@ -69,7 +70,7 @@ numbers that can't be proved in Peano arithmetic!
 \end{enumerate}
 \end{defn}
 
-There are ways of stating the definition; for example, we could
+There are other ways of stating the definition; for example, we could
 equivalently require that $\Th{Q}$ proves $\lforall[y][(!A_f(\bar n_0, \dots,
 \bar n_k,y) \liff \bar m = y)]$.
 

--- a/incompleteness/representability-in-q/representable-comp.tex
+++ b/incompleteness/representability-in-q/representable-comp.tex
@@ -15,7 +15,7 @@ Every function that is representable in $\Th{Q}$ is computable.
 
 \begin{proof}
 All we need to know is that we can code terms, formulas, and proofs in
-such a way that the relation ``$d$ is a proof of $!A$ in theory
+such a way that the relation ``$d$ is a proof of $!A$ in the theory
 $\Th{Q}$'' is computable, as well as the function
 $\fn{SubNumeral}(!A,n,v)$ which returns (a numerical code of) the
 result of substituting the numeral corresponding to $n$ for the

--- a/incompleteness/representability-in-q/undecidability.tex
+++ b/incompleteness/representability-in-q/undecidability.tex
@@ -14,7 +14,7 @@ computational procedure which, after finitely many steps and
 unfailingly, provides a correct answer to the question ``does $\Th{T}$
 prove~$!A$'' for any sentence~$!A$ in the language of~$\Th{T}$.  So
 $\Th{Q}$ would be decidable iff there were a computational procedure
-which decides, given a sentence~$A$ in the language of arithmetic,
+which decides, given a sentence~$!A$ in the language of arithmetic,
 whether $\Th{Q} \Proves !A$ or not.  We can make this more precise by
 asking: Is the relation~$\fn{Prov}_{\Th{Q}}(y)$, which holds of~$y$
 iff $y$ is the G\"odel number of a sentence provable in~$\Th{Q}$,
@@ -30,13 +30,14 @@ is not recursive.
 \end{thm}
 
 \begin{proof}
+% You haven't defined omega-consistency yet but use it in this proof.
 Suppose it were.  Then we could solve the halting problem as follows:
 Given $e$ and $n$, we know that $\cfind{e}(n) \defined$ iff there is
 an~$s$ such that $T(e, n, s)$, where $T$ is Kleene's predicate from
 \olref[cmp][rec][nft]{thm:kleene-nf}. Since $T$ is primitive recursive
 it is representable in~$\Th{Q}$ by a formula $!B_T$, that is, $\Th{Q}
 \Proves !B_T(\num{e}, \num{n}, \num{s})$ iff $T(e, n, s)$.  If $\Th{Q}
-\Proves !B_T(\num{e}, \num{n}, \num{s})$ then also $\Th{Q} \Proves
+\Proves !B_T(\num{e}, \num{n}, \num{s})$ then also $
 \Th{Q} \Proves \lexists[y][!B_T(\num{e}, \num{n}, y)]$. If no such $s$
 exists, then $\Th{Q} \Proves \lnot !B_T(\num{e}, \num{n}, \num{s})$
 for every~$s$. Since $\Th{Q}$ is $\omega$-consistent, $\Th{Q} \Proves/


### PR DESCRIPTION
Fixing several typos in the chapters on recursive functions and
arithmetization of syntax.  Also including some notes on various proofs
which might need to be changed.