### PR TITLE
Lightly copyedit the text

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 The Open Logic Project
 ======================
 
-The OLP is an open source, open access textbook on advanced logic, aimed at philosophers, but also suitable for computer scientists and mathematicians. The text is a template from which custom books can be produced, depending on the aim of the course and the preferences of the instructor. It is written  in LaTeX.
+The OLP is an open source, open access textbook on advanced logic, aimed at philosophers, but also suitable for computer scientists and mathematicians. The text is a template from which custom books can be produced, depending on the aim of the course and the preferences of the instructor. It is written in LaTeX.
 
-For more information, see the <a href="http://openlogicproject.org/">project website</a> and <a href="https://github.com/OpenLogicProject/OpenLogic/wiki">Open Logic wiki</a> .
+For more information, see the <a href="http://openlogicproject.org/">project website</a> and <a href="https://github.com/OpenLogicProject/OpenLogic/wiki">Open Logic wiki</a>.
 
 Author(s): The Open Logic Project
 

--- a/computability/computability-theory/application-fixed-point.tex
+++ b/computability/computability-theory/application-fixed-point.tex
@@ -10,7 +10,7 @@
 \olsection{Applying the Fixed-Point Theorem}
 
 The fixed-point theorem essentially lets us define partial computable
-functions in terms of their indices.  For example, we can find an
+functions in terms of their indices. For example, we can find an
 index $e$ such that for every $y$,
 \[
 \cfind{e}(y) = e + y.
@@ -20,10 +20,10 @@ to design a program in Java or C++ that prints itself out.
 
 Remember that if for each $e$, we let $W_e$ be the domain of $\cfind{e}$,
 then the sequence $W_0$, $W_1$, $W_2$,~\dots enumerates the computably
-enumerable sets.  Some of these sets are computable. One can ask if
+enumerable sets. Some of these sets are computable. One can ask if
 there is an algorithm which takes as input a value $x$, and, if $W_x$
 happens to be computable, returns an index for its characteristic
-function.  The answer is ``no,'' there is no such algorithm:
+function. The answer is ``no,'' there is no such algorithm:
 
 \begin{thm}
 There is no partial computable function $f$ with the following
@@ -37,7 +37,7 @@ such that $W_e$ is computable, but $\cfind{f(e)}$ is not its
 characteristic function. Using the fixed point theorem, we can find an
 index $e$ such that
 \[
-\cfind{e}(y) \simeq 
+\cfind{e}(y) \simeq
 \begin{cases}
 0 & \text{if $y=0$ and $\cfind{f(e)}(0) \defined = 0$} \\
 \text{undefined} & \text{otherwise.}
@@ -46,7 +46,7 @@ index $e$ such that
 That is, $e$ is obtained by applying the fixed-point theorem to the
 function defined by
 \[
-g(x,y) \simeq 
+g(x,y) \simeq
 \begin{cases}
 0 & \text{if $y=0$ and $\cfind{f(x)}(0) \defined = 0$} \\
 \text{undefined} & \text{otherwise.}

--- a/computability/computability-theory/ce-closed-cup-cap.tex
+++ b/computability/computability-theory/ce-closed-cup-cap.tex
@@ -48,12 +48,12 @@ k(x) = \begin{cases}
 f(x/2) & \text{if $x$ is even} \\
 g((x-1)/2) & \text{if $x$ is odd.}
 \end{cases}
-\] 
+\]
 Then $k$ enumerates $A \cup B$; the idea is that $k$ just alternates
 between the enumerations offered by $f$ and $g$. Enumerating $A \cap
 B$ is tricker. If $A \cap B$ is empty, it is trivially computably
 enumerable. Otherwise, let $c$ be any element of $A \cap B$, and
-define $l$ by 
+define $l$ by
 \[
 l(x) = \begin{cases}
 f((x)_0) & \text{if $f((x)_0) = g((x)_1)$} \\
@@ -67,12 +67,12 @@ otherwise, it just stalls by outputting $c$.
 For the last proof, suppose $A$ is the \emph{domain} of the partial
 function $m(x)$ and $B$ is the domain of the partial function
 $n(x)$. Then $A \cap B$ is the domain of the partial function $m(x) +
-n(x)$. 
+n(x)$.
 
 \begin{explain}
 In computational terms, if $A$ is the set of values for which
 $m$ halts and $B$ is the set of values for which $n$ halts, $A \cap B$
-is the set of values for which both procedures halt. 
+is the set of values for which both procedures halt.
 \end{explain}
 
 Expressing $A \cup B$ as a set of halting values is more difficult,
@@ -86,7 +86,7 @@ p(x) = \umin{y}{(T(d,x,y) \lor T(e,x,y))}.
 \begin{explain}
 In computational terms, on input $x$, $p$ searches for either a
 halting computation for $m$ or a halting computation for $n$, and
-halts if it finds either one. 
+halts if it finds either one.
 \end{explain}
 \end{proof}
 

--- a/computability/computability-theory/ce-sets.tex
+++ b/computability/computability-theory/ce-sets.tex
@@ -18,7 +18,7 @@ computable function.
 Computably enumarable sets are also called \emph{recursively
   enumerable} instead. This is the original terminology, and today
 both are commonly used, as well as the abbreviations ``c.e.'' and
-``r.e.'' 
+``r.e.''
 \end{history}
 
 \begin{explain}
@@ -40,7 +40,7 @@ $S$~is computable. If $S$ is empty, then by definition it is
 computably enumerable. Otherwise, let $a$ be any element of
 $S$. Define $f$ by
 \[
-f(x) = 
+f(x) =
 \begin{cases}
 x & \text{if $\Char{S}(x) = 1$} \\
 a & \text{otherwise.}

--- a/computability/computability-theory/coding-computations.tex
+++ b/computability/computability-theory/coding-computations.tex
@@ -33,7 +33,7 @@ Using coding, it is possible to assign to each description of a
 computable function a numerical \emph{index} in such a way that the
 instructions can be recovered from the index in a computable way.
 Similarly, the complete record of a computation can be coded by a
-single number as well.  The resulting arithmetical relation ``$s$
+single number as well. The resulting arithmetical relation ``$s$
 codes the record of computation of the function with index~$e$ for
 input~$x$'' and the function ``output of computation sequence with
 code~$s$'' are then computable; in fact, they are primitive recursive.

--- a/computability/computability-theory/complement-ce.tex
+++ b/computability/computability-theory/complement-ce.tex
@@ -45,7 +45,7 @@ $A$~is computable.
 It is easier to understand what is going on in informal computational
 terms: to decide $A$, on input $x$ search for halting computations of
 $\cfind{e}$ and $\cfind{f}$. One of them is bound to halt; if it is $\cfind{e}$,
-then $x$ is in~$A$, and otherwise, $x$ is in~$\Complement{A}$. 
+then $x$ is in~$A$, and otherwise, $x$ is in~$\Complement{A}$.
 \end{explain}
 
 \begin{cor}

--- a/computability/computability-theory/complete-ce-sets.tex
+++ b/computability/computability-theory/complete-ce-sets.tex
@@ -28,7 +28,7 @@ $K$, $K_0$, and $K_1$ are all complete computably enumerable sets.
 
 \begin{proof}
 To see that $K_0$ is complete, let $B$ be any computably
-enumerable set. Then for some index $e$, 
+enumerable set. Then for some index $e$,
 \[
 B = W_e = \Setabs{x}{\cfind{e}(x) \defined}.
 \]
@@ -53,7 +53,7 @@ So, it turns out that all the examples of computably enumerable sets
 that we have considered so far are either computable, or complete.
 This should seem strange!{} Are there any examples of computably
 enumerable sets that are neither computable nor complete? The answer
-is yes, but it wasn't until the middle of the 1950's that this was
+is yes, but it wasn't until the middle of the 1950s that this was
 established by Friedberg and Muchnik, independently.
 \end{digress}
 

--- a/computability/computability-theory/computable-sets.tex
+++ b/computability/computability-theory/computable-sets.tex
@@ -17,7 +17,7 @@ computable sets:
   iff its characteristic function is. In other words, $S$ is
   computable iff the function
 \[
-\Char{S}(x) = 
+\Char{S}(x) =
 \begin{cases}
 1 & \text{if $x \in S$} \\
 0 & \text{otherwise}

--- a/computability/computability-theory/def-functions-self-reference.tex
+++ b/computability/computability-theory/def-functions-self-reference.tex
@@ -7,14 +7,14 @@
 \begin{document}
 
 \olfileid{cmp}{thy}{slf}
-\olsection{Defining Functions using Self-Reference} 
+\olsection{Defining Functions using Self-Reference}
 
 It is generally useful to be able to define functions in terms of
 themselves. For example, given computable functions $k$, $l$, and~$m$,
 the fixed-point lemma tells us that there is a partial computable
 function~$f$ satisfying the following equation for every~$y$:
 \[
-f(y) \simeq 
+f(y) \simeq
 \begin{cases}
 k(y) & \text{if $l(y) = 0$} \\
 f(m(y)) & \text{otherwise.}

--- a/computability/computability-theory/equiv-ce-defs.tex
+++ b/computability/computability-theory/equiv-ce-defs.tex
@@ -6,12 +6,12 @@
 
 \begin{document}
 
-\olfileid{cmp}{thy}{eqc} 
+\olfileid{cmp}{thy}{eqc}
 
 \olsection[Definitions of C. E. Sets]{Equivalent Defininitions of
   Computably Enumerable Sets}
 
- 
+
 The following gives a number of important equivalent statements of
 what it means to be computably enumerable.
 
@@ -120,7 +120,7 @@ $\cfind{e}(x) \defined$, i.e., if and only if $x \in S$. \iftag{TMs}{Expressed
 in terms of Turing machines: given a machine $M_e$ that semi-decides
 $S$, enumerate the elements of $S$ by running through all possible
 Turing machine computations, and returning the inputs that correspond
-to halting computations.}{} 
+to halting computations.}{}
 \end{proof}
 
 The fourth clause of \olref{thm:ce-equiv} provides us with a
@@ -152,7 +152,7 @@ In the reverse direction, suppose $S = \Setabs{ x }{
 \[
 f(x) \simeq \umin{y}{Atom{R}{x,y}}.
 \]
-Then $f$ is partial computable, and $S$ is the domain of~$f$. 
+Then $f$ is partial computable, and $S$ is the domain of~$f$.
 \end{proof}
 
 

--- a/computability/computability-theory/fixed-point-thm.tex
+++ b/computability/computability-theory/fixed-point-thm.tex
@@ -13,12 +13,12 @@ Let's consider the halting problem again. As temporary
 notation, let us write $\gn{\cfind{x}(y)}$ for $\tuple{x, y}$; think of
 this as representing a ``name'' for the value $\cfind{x}(y)$. With this
 notation, we can reword one of our proofs that the halting problem is
-undecidable. 
+undecidable.
 
 Question: is there a computable function $h$, with the
-following property?  For every $x$ and $y$,
+following property? For every $x$ and $y$,
 \[
-h(\gn{\cfind{x}(y)}) = 
+h(\gn{\cfind{x}(y)}) =
 \begin{cases}
 1 & \text{if $\cfind{x}(y) \defined$} \\
 0 & \text{otherwise.}
@@ -27,7 +27,7 @@ h(\gn{\cfind{x}(y)}) =
 
 Answer: No; otherwise, the partial function
 \[
-g(x) \simeq 
+g(x) \simeq
 \begin{cases}
 0 & \text{if $h(\gn{\cfind{x}(x)}) = 0$} \\
 \text{undefined} & \text{otherwise}
@@ -35,14 +35,14 @@ g(x) \simeq
 \]
 would be computable, and so have some index~$e$. But then we have
 \[
-\cfind{e}(e) \simeq 
+\cfind{e}(e) \simeq
 \begin{cases}
 0 & \text{if $h(\gn{\cfind{e}(e)}) = 0$} \\
 \text{undefined} & \text{otherwise,}
 \end{cases}
 \]
 in which case $\cfind{e}(e)$ is defined if and only if it isn't, a
-contradiction. 
+contradiction.
 
 Now, take a look at the equation with $\cfind{e}$. There is an instance of
 self-reference there, in a sense: we have arranged for the value of
@@ -62,7 +62,7 @@ theorem.
 The following statements are equivalent:
 \begin{enumerate}
 \item For every partial computable function $g(x,y)$, there is an
-  index~$e$ such that for every~$y$, 
+  index~$e$ such that for every~$y$,
 \[
 \cfind{e}(y) \simeq g(e,y).
 \]
@@ -86,10 +86,10 @@ $(2) \Rightarrow (1)$: Given $g$, use the $s$-$m$-$n$ theorem to get $f$ such
 that for every $x$ and~$y$, $\cfind{f(x)}(y) \simeq g(x,y)$. Use (2) to
 get an index~$e$ such that
 \begin{align*}
-\cfind{e}(y) & = \cfind{f(e)}(y) \\ 
+\cfind{e}(y) & = \cfind{f(e)}(y) \\
 & = g(e,y).
 \end{align*}
-This concludes the proof. 
+This concludes the proof.
 \end{proof}
 
 \begin{explain}
@@ -145,7 +145,7 @@ Then for every $y$, we have
 & \simeq g(\fn{diag}(\gn{l}),y) \\
 & \simeq g(e, y),
 \end{align*}
-as required. 
+as required.
 \end{proof}
 
 \begin{explain}
@@ -187,7 +187,7 @@ string $x$ repeatedly, $y$ times. Then the ``program''
 getinput(y); print(diag('getinput(y); print(diag(x), y)'), y)
 \end{verbatim}
 \end{quote}
-prints itself out $y$ times, on input $y$. Replacing the 
+prints itself out $y$ times, on input $y$. Replacing the
 $\fn{getinput}$---$\fn{print}$---$\fn{diag}$ skeleton by an
 arbitrary funtion $g(x,y)$ yields
 \begin{quote}

--- a/computability/computability-theory/halting-problem.tex
+++ b/computability/computability-theory/halting-problem.tex
@@ -12,8 +12,8 @@
 Since, in our construction, $\fn{Un}(k,x)$ is defined if and only if
 the computation of the function coded by~$k$ produces a value for
 input~$x$, it is natural to ask if we can decide whether this is the
-case.  And in fact, it is not.  For the Turing machine model of
-computation, this means that the question as to whether a given Turing
+case. And in fact, it is not. For the Turing machine model of
+computation, this means that whether a given Turing
 machine halts on a given input is computationally undecidable. The
 following theorem is therefore known as the ``undecidability of the
 halting problem.'' I will provide two proofs below. The first
@@ -24,7 +24,7 @@ more direct.
 \ollabel{thm:halting-problem}
 Let
 \[
-h(k, x)  = 
+h(k, x)  =
 \begin{cases}
 1 & \text{if $\fn{Un}(k,x)$ is defined} \\
 0 & \text{otherwise.}
@@ -37,7 +37,7 @@ Then $h$ is not computable.
 If $h$ were computable, we would have a universal computable function,
 as follows. Suppose $h$ is computable, and define
 \[
-\fn{Un'}(k,x) = 
+\fn{Un'}(k,x) =
 \begin{cases}
 fn{Un}(k,x) & \text{if $h(k,x) = 1$} \\
 0 & \text{otherwise.}
@@ -48,8 +48,8 @@ is.  For instance, we could define $g$ using primitive recursion, by
 \begin{align*}
 g(0, k, x) & \simeq 0 \\
 g(y+1, k, x) & \simeq \fn{Un}(k,x);
-\end{align*} 
-then 
+\end{align*}
+then
 \[
 \fn{Un'}(k,x) \simeq g(h(k,x),k,x).
 \]
@@ -62,7 +62,7 @@ computable functions that happen to be total.  But this contradicts
 \begin{proof}
 Suppose $h(k,x)$ were computable. Define the function $g$ by
 \[
-g(x) = 
+g(x) =
 \begin{cases}
   0                & \text{if $h(x,x) = 0$} \\
   \text{undefined} & \text{otherwise.}
@@ -76,7 +76,7 @@ $\fn{Un}(k, k)$ is undefined; but by our assumption that $g(k) \simeq
 \fn{Un}(k, x)$ for every $x$, this means that $g(k)$ is undefined, a
 contradiction. On the other hand, if $g(k)$ is undefined, then $h(k,k)
 \neq 0$, and so $h(k,k) = 1$. But this means that $\fn{Un}(k, k)$ is
-defined, i.e., that $g(k)$ is defined. 
+defined, i.e., that $g(k)$ is defined.
 \end{proof}
 
 \begin<TMs>{explain}

--- a/computability/computability-theory/introduction.tex
+++ b/computability/computability-theory/introduction.tex
@@ -17,12 +17,12 @@ today, both names are commonly used.
 
 Let us call a function~$f\colon \Nat \pto \Nat$ \emph{partial
   computable} if it can be computed in some model of computation. If
-$f$ is total we will simply say that $f$ is \emph{computable}.  A
+$f$ is total we will simply say that $f$ is \emph{computable}. A
 relation $R$ with computable characteristic function~$\Char{R}$ is
 also called computable. If $f$ and $g$ are partial functions, we will
 write $f(x) \defined$ to mean that $f$ is defined at $x$, i.e., $x$ is
 in the domain of $f$; and $f(x) \undefined$ to mean the opposite,
-i.e., that $f$ is not defined at~$x$.  We will use $f(x) \simeq g(x)$
+i.e., that $f$ is not defined at~$x$. We will use $f(x) \simeq g(x)$
 to mean that either $f(x)$ and $g(x)$ are both undefined, or they are
 both defined and equal.
 
@@ -57,7 +57,7 @@ two ways one can proceed:
 \item Informally: describe an algorithm that computes it, and appeal to
   Church's thesis.
 \end{enumerate}
-There is no fine line between the two; a very detailed description of
+There is no fine line between the two; a detailed description of
 an algorithm should provide enough information so that it is
 relatively clear how one could, in principle, design the right Turing
 machine or sequence of partial recursive definitions. Fully rigorous

--- a/computability/computability-theory/k-1.tex
+++ b/computability/computability-theory/k-1.tex
@@ -22,10 +22,10 @@ Then $K_1$ is computably enumerable but not computable.
 
 \begin{proof}
 Since $K_1 = \Setabs{e}{\lexists[s][T(e,0,s)]}$, $K_1$ is computably
-enumerable by \olref[eqc]{thm:exists-char}. 
+enumerable by \olref[eqc]{thm:exists-char}.
 
 To show that $K_1$ is not computable, let us show that $K_0$ is
-reducible to it. 
+reducible to it.
 
 \begin{explain}
 This is a little bit tricky, since using $K_1$ we can
@@ -55,7 +55,7 @@ that $f = \cfind{e}[3]$; so we have
 \cfind{e}[3](x,y,z) \simeq \cfind{x}(y).
 \]
 By the $s$-$m$-$n$ theorem, there is a function $s(e,x,y)$ such that, for
-every $z$, 
+every $z$,
 \begin{align*}
 \cfind{s(e,x,y)}(z) & \simeq \cfind{e}[3](x,y,z) \\
 & \simeq \cfind{x}(y).
@@ -64,7 +64,7 @@ every $z$,
 \begin{explain}
 In terms of the informal argument above, $s(e,x,y)$ is an index for
 the machine that, for any input $z$, ignores that input and computes
-$\cfind{x}(y)$. 
+$\cfind{x}(y)$.
 \end{explain}
 
 In particular, we have
@@ -77,7 +77,7 @@ K_1$. So the function $g$ defined by
 \[
 g(w) = s(e,(w)_0,(w)_1)
 \]
-is a reduction of $K_0$ to~$K_1$. 
+is a reduction of $K_0$ to~$K_1$.
 \end{proof}
 
 \end{document}

--- a/computability/computability-theory/minimization-lambda.tex
+++ b/computability/computability-theory/minimization-lambda.tex
@@ -7,7 +7,7 @@
 \begin{document}
 
 \olfileid{cmp}{thy}{mla}
-\olsection{Minimization with Lambda Terms} 
+\olsection{Minimization with Lambda Terms}
 
 When it comes to the lambda calculus, we've shown the following:
 \begin{enumerate}
@@ -33,7 +33,7 @@ for a $y$ starting at~$n$; then $g(x)$ is just
 $h_x(0)$. The function $h_x$ can be expressed as the solution of a
 fixed-point equation:
 \[
-h_x(n) \simeq 
+h_x(n) \simeq
 \begin{cases}
 n & \text{if $f(x,n) = 0$} \\
 h_x(n+1) & \text{otherwise.}

--- a/computability/computability-theory/no-universal-function.tex
+++ b/computability/computability-theory/no-universal-function.tex
@@ -10,7 +10,7 @@
 \olsection{No Universal Computable Function}
 
 \begin{thm}
-\ollabel{thm:no-univ} 
+\ollabel{thm:no-univ}
 There is no universal computable function. In other words, the
 universal function $\fn{Un'}(k, x) = \cfind{k}(x)$ is not
 computable.

--- a/computability/computability-theory/normal-form.tex
+++ b/computability/computability-theory/normal-form.tex
@@ -10,7 +10,7 @@
 \olsection{The Normal Form Theorem}
 
 \begin{thm}[Kleene's Normal Form Theorem]
-\ollabel{thm:normal-form} 
+\ollabel{thm:normal-form}
 There are a primitive recursive relation $T(k, x, s)$ and a primitive
 recursive function $U(s)$, with the following property: if $f$ is any
 partial computable function, then for some~$k$,
@@ -25,8 +25,8 @@ For any model of computation one can rigorously define a description
 of the computable function~$f$ and code such description using a
 natural number~$k$.  One can also rigorously define a notion of
 ``computation sequence'' which records the process of computing the
-function with index~$k$ for input~$x$. These computation sequences can
-likewise be coded as numbers~$s$. This can be done in such a way that
+function with index~$k$ for input~$x$.  These computation sequences can
+likewise be coded as numbers~$s$.  This can be done in such a way that
 (a) it is decidable whether a number $s$ codes the computation
 sequence of the function with index~$k$ on input~$x$ and (b) what the
 end result of the computation sequence coded by~$s$ is.  In fact, the
@@ -61,13 +61,13 @@ Here is another useful fact:
 Every partial computable function has infinitely many indices.
 \end{thm}
 
-Again, this is intuitively clear. Given any (description of) a
+Again, this is intuitively clear.  Given any (description of) a
 computable function, one can come up with a different description
 which computes the same function (input-output pair) but does so,
 e.g., by first doing something that has no effect on the computation
 (say, test if $0 = 0$, or count to $5$, etc.).  The index of the
 altered description will always be different from the original
-index. Both are indices of the same function, just computed slightly
+index.  Both are indices of the same function, just computed slightly
 differently.
 
 \end{document}

--- a/computability/computability-theory/prop-reduce.tex
+++ b/computability/computability-theory/prop-reduce.tex
@@ -36,7 +36,7 @@ Let $f$ be a many-one reduction from $A$ to $B$. For the first
 claim, just check that if $B$ is the domain of a partial function~$g$,
 then $A$ is the domain of~$g \circ f$:
 \begin{align*}
-x \in A & \text{iff } f(x) \in B \\ 
+x \in A & \text{iff } f(x) \in B \\
 & \text{iff }  g(f(x)) \defined.
 \end{align*}
 
@@ -58,7 +58,7 @@ computably enumerable. But, intuitively, if you knew the answers to
 questions about $K_0$, you would know the answer to questions about
 its complement as well. A set $A$ is said to be Turing reducible
 to~$B$ if one can determine answers to questions in~$A$ using a
-computable procedure that can ask questions about~$B$.  This is more
+computable procedure that can ask questions about~$B$. This is more
 liberal than many-one reducibility, in which (1) you are only allowed
 to ask one question about $B$, and (2) a ``yes'' answer has to
 translate to a ``yes'' answer to the question about $A$, and similarly

--- a/computability/computability-theory/reducibility.tex
+++ b/computability/computability-theory/reducibility.tex
@@ -12,7 +12,7 @@
 \begin{explain}
 We now know that there is at least one set, $K_0$, that is computably
 enumerable but not computable. It should be clear that there are
-others. The method of reducibility provides a very powerful method of
+others. The method of reducibility provides a powerful method of
 showing that other sets have these properties, without constantly
 having to return to first principles.
 
@@ -37,7 +37,7 @@ in unsolvable, \olref[hlt]{thm:halting-problem}, shows most directly
 that $K$ is not computable. Recall that $K_0$ is the set
 \[
 K_0 = \Setabs{\tuple{e, x}}{\cfind{e}(x) \defined }.
-\] 
+\]
 i.e. $K_0 = \Setabs{\tuple{x,e}}{x \in W_e}$. It is easy to extend any
 proof of the uncomputability of $K$ to the uncomputability of $K_0$:
 if $K_0$ were computable, we could decide whether or not an element
@@ -60,7 +60,7 @@ are said to be \emph{many-one equivalent}, written $A \equiv_m B$.
 If the function $f$ in the definition above happens to be injective,
 $A$ is said to be \emph{one-one reducible} to $B$. Most of the
 reductions described below meet this stronger requirement, but we will
-not use this fact. 
+not use this fact.
 
 \begin{digress}
 It is true, but by no means obvious, that one-one reducibility really

--- a/computability/computability-theory/rice-theorem.tex
+++ b/computability/computability-theory/rice-theorem.tex
@@ -30,7 +30,7 @@ standard enumeration of the partial computable functions.
 An {\em index set} is a set $A$ with the property that if $n$ and $m$
 are indices which ``compute'' the same function, then either both $n$
 and $m$ are in $A$, or neither is. It is not hard to see that the
-set~$A$ in the theorem has this property.  Conversely, if $A$~is an
+set~$A$ in the theorem has this property. Conversely, if $A$~is an
 index set and $C$~is the set of functions computed by these indices,
 then $A = \Setabs{n}{\cfind{n} \in C}$.
 
@@ -50,7 +50,7 @@ halt on input $0$? Does it ever halt? Does it ever output an even
 number?
 \end{explain}
 
-\begin{proof}[Proof of Rice's theorem] 
+\begin{proof}[Proof of Rice's theorem]
 Suppose $C$ is neither $\emptyset$ nor the set of all the partial
 computable functions, and let $A$ be the set of indices of functions
 in~$C$. We will show that if $A$ were computable, we could solve the
@@ -66,7 +66,7 @@ could use that capability to solve the halting problem.
 Here's how. Using the universal computation predicate, we can define a
 function
 \[
-h(x,y) \simeq 
+h(x,y) \simeq
 \begin{cases}
 \text{undefined} & \text{if $\cfind{x}(x) \undefined$} \\
 g(y) & \text{otherwise.}
@@ -74,7 +74,7 @@ g(y) & \text{otherwise.}
 \]
 To compute $h$, first we try to compute $\cfind{x}(x)$; if that
 computation halts, we go on to compute $g(y)$; and if {\em that}
-computation halts, we return the output. More formally, we can write 
+computation halts, we return the output. More formally, we can write
 \[
 h(x,y) \simeq \Proj{2}{0}(g(y),\fn{Un}(x,x)).
 \]
@@ -101,12 +101,12 @@ $\cfind{s(k,x)}(y) = h_x(y)$. Now we have that for each $x$, if
 $\cfind{x}(x) \defined$, then $\cfind{s(k,x)}$ is the same function
 as~$g$, and so $s(k,x)$ is in $A$. On the other hand, if $\cfind{x}(x)
 \uparrow$, then $\cfind{s(k,x)}$ is the same function as $f$, and so
-$s(k,x)$ is not in $A$.  In other words we have that for every $x$, $x
+$s(k,x)$ is not in $A$. In other words we have that for every $x$, $x
 \in K$ if and only if $s(k,x) \in A$. If $A$ were computable, $K$
 would be also, which is a contradiction. So $A$ is not computable.
 \end{proof}
 
-Rice's theorem is very powerful. The following immediate corollary
+Rice's theorem is powerful. The following immediate corollary
 shows some sample applications.
 \begin{cor}
 The following sets are undecidable.

--- a/computability/computability-theory/russells-paradox.tex
+++ b/computability/computability-theory/russells-paradox.tex
@@ -14,7 +14,7 @@ this section with Russell's paradox:
 \begin{enumerate}
 \item Russell's paradox: let $S = \Setabs{x}{x \notin x}$. Then $x
   \in S$ if and only if $x \notin S$, a contradiction.
-  
+
   \emph{Conclusion:} There is no such set~$S$. Assuming the existence of a
   ``set of all sets'' is inconsistent with the other axioms of set
   theory.
@@ -22,7 +22,7 @@ this section with Russell's paradox:
 \item A modification of Russell's paradox: let $F$ be the ``function''
   from the set of all functions to $\{ 0, 1 \}$, defined by
   \[
-  F(f) = 
+  F(f) =
   \begin{cases}
     1 & \text{if $f$ is in the domain of $f$, and $f(f) = 0$} \\
     0 & \text{otherwise}
@@ -33,12 +33,12 @@ this section with Russell's paradox:
 
   \emph{Conclusion:} $F$ is not a function. The ``set of all
   functions'' is too big to be the domain of a function.
-  
+
 \item The diagonalization argument: let $f_0$, $f_1$, \dots be the
   enumeration of the partial computable functions, and let $G \colon \Nat \to
   \{ 0, 1 \}$ be defined by
   \[
-  G(x) = 
+  G(x) =
   \begin{cases}
     1 & \text{if $f_x(x)\downarrow = 0$} \\
     0 & \text{otherwise}

--- a/computability/computability-theory/s-m-n.tex
+++ b/computability/computability-theory/s-m-n.tex
@@ -35,7 +35,7 @@ $s^m_n(x, a_0, \dots, a_{m-1})$, for the $n$-ary function of the
 remaining arguments. \iftag{TMs}{It you think of $x$ as the description of a
 Turing machine, then $s^m_n(x, a_0, \dots, a_{m-1})$ is the Turing
 machine that, on input $y_0$, \dots,~$y_{n-1}$, prepends
-$a_0$, \dots,~$a_{m-1}$ to the input string, and runs $x$.  Each $s^m_n$
+$a_0$, \dots,~$a_{m-1}$ to the input string, and runs $x$. Each $s^m_n$
 is then just a primitive recursive function that finds a code for the
 appropriate Turing machine.}{}
 \end{explain}

--- a/computability/computability-theory/total.tex
+++ b/computability/computability-theory/total.tex
@@ -25,30 +25,30 @@ $\fn{Tot}$ is not computable.
 To see that $\fn{Tot}$ is not computable, it suffices to show that $K$
 is reducible to it. Let $h(x,y)$ be defined by
 \[
-h(x,y) \simeq 
+h(x,y) \simeq
 \begin{cases}
 0 & \text{if $x \in K$} \\
 \text{undefined} & \text{otherwise}
 \end{cases}
 \]
-Note that $h(x,y)$ does not depend on $y$ at all.  It should
+Note that $h(x,y)$ does not depend on $y$ at all. It should
 not be hard to see that $h$~is partial computable: on input $x, y$, the
 we compute~$h$ by first simulating the function~$\cfind{x}$ on input~$x$; if
 this computation halts, $h(x,y)$ outputs $0$ and halts. So
 $h(x,y)$ is just $Z(\umin{s}{T(x,x,s))}$, where $Z$ is the constant zero
-function. 
+function.
 
 Using the $s$-$m$-$n$ theorem, there is a primitive recursive
 function~$k(x)$ such that for every $x$ and~$y$,
 \[
-\cfind{k(x)}(y) = 
+\cfind{k(x)}(y) =
 \begin{cases}
 0 & \text{if $x \in K$} \\
 \text{undefined} & \text{otherwise}
 \end{cases}
 \]
 So $\cfind{k(x)}$ is total if $x \in K$, and undefined otherwise. Thus,
-$k$ is a reduction of $K$ to $\fn{Tot}$. 
+$k$ is a reduction of $K$ to $\fn{Tot}$.
 \end{proof}
 
 \begin{digress}

--- a/computability/computability-theory/universal-part-function.tex
+++ b/computability/computability-theory/universal-part-function.tex
@@ -22,7 +22,7 @@ natural number $k$ such that $f(x) \simeq \fn{Un}(k,x)$ for every $x$.
 
 \begin{proof}
 Let $\fn{Un}(k,x) \simeq U(\umin{s}{T(k,x,s)})$ in Kleene's
-normal form theorem. 
+normal form theorem.
 \end{proof}
 
 \begin{explain}

--- a/computability/lambda-calculus/basic-pr-lambda.tex
+++ b/computability/lambda-calculus/basic-pr-lambda.tex
@@ -15,7 +15,7 @@ The functions $0$, $S$, and $\Proj{n}{i}$ are lambda representable.
 
 \begin{proof}
 Zero, $\num{0}$, is just
-$\lambd[x][\lambd[y][y]]$. 
+$\lambd[x][\lambd[y][y]]$.
 
 The successor function~$\num{S}$, is
 defined by $\num{S}(u) = \lambd[x][\lambd[y][x(uxy)]]$. You should

--- a/computability/lambda-calculus/computable-lambda.tex
+++ b/computability/lambda-calculus/computable-lambda.tex
@@ -10,7 +10,7 @@
 \olsection{Computable Functions are Lambda Representable}
 
 \begin{thm}
-\ollabel{thm:computable-lambda} 
+\ollabel{thm:computable-lambda}
 Every computable partial function if representable by a lambda term.
 \end{thm}
 

--- a/computability/lambda-calculus/introduction.tex
+++ b/computability/lambda-calculus/introduction.tex
@@ -38,7 +38,7 @@ conventional notation, of course, we write~$f(2)$ for the result.
 
 What happens when you combine lambda abstraction with application?
 Then the resulting expression can be simplified, by ``plugging'' the
-applicand in for the abstracted variable. For example, 
+applicand in for the abstracted variable. For example,
 \[
 (\lambd[x][(x + 3)])(2)
 \]
@@ -55,7 +55,7 @@ radical departure from the set-theoretic viewpoint. In this framework:
 For example, if $F$ is a term in the lambda calculus, $F(F)$ is always
 assumed to be meaningful. This liberal framework is known as the
 \emph{untyped} lambda calculus, where ``untyped'' means ``no
-restriction on what can be applied to what.'' 
+restriction on what can be applied to what.''
 
 \begin{digress}
 There is also a \emph{typed} lambda calculus, which is an important

--- a/computability/lambda-calculus/lambda-computable.tex
+++ b/computability/lambda-calculus/lambda-computable.tex
@@ -10,7 +10,7 @@
 \olsection{Lambda Representable Functions are Computable}
 
 \begin{thm}
-\ollabel{thm:lambda-computable} 
+\ollabel{thm:lambda-computable}
 If a partial function $f$ is represented by a lambda term, it is
 computable.
 \end{thm}

--- a/computability/lambda-calculus/minimization.tex
+++ b/computability/lambda-calculus/minimization.tex
@@ -23,7 +23,7 @@ lambda term $Y$ to define a function $h_x(n)$ which searches for a~$y$
 starting at~$n$; then $g(x)$ is just $h_x(0)$. The function~$h_x$ can
 be expressed as the solution of a fixed-point equation:
 \[
-h_x(n) \simeq 
+h_x(n) \simeq
 \begin{cases}
 n & \text{if $f(x,n) = 0$} \\
 h_x(n+1) & \text{otherwise.}
@@ -33,7 +33,7 @@ h_x(n+1) & \text{otherwise.}
 Here are the details. Since $f$ is primitive recursive, it is
 represented by some term $F$. Remember that we also have a lambda
 term~$D$, such that $D(M, N, \bar{0}) \red M$ and $D(M, N, \bar{1})
-\red N$.  Fixing $x$ for the moment, to represent $h_x$ we want to
+\red N$. Fixing $x$ for the moment, to represent $h_x$ we want to
 find a term~$H$ (depending on~$x$) satisfying
 \[
 H(\num{n}) \equiv D(\num{n}, H(S(\num{n})), F(x, \num{n})).

--- a/computability/lambda-calculus/primitive-recursion.tex
+++ b/computability/lambda-calculus/primitive-recursion.tex
@@ -13,7 +13,7 @@ When it comes to primitive recursion, we finally need to do some
 work. We will have to proceed in stages. As before, on the assumption
 that we already have terms $\num{g}$ and $\num{h}$ representing functions
 $g$ and~$h$, respectively, we want a term $\num{f}$ representing the
-function~$f$ defined by 
+function~$f$ defined by
 \begin{align*}
 f(0, \vec z) & = g(\vec z) \\
 f(x+1, \vec z) & = h(z, f(x,\vec z), \vec z).
@@ -50,7 +50,7 @@ and~$N$, $D(M,N)(\num{0}) \red M$ and $D(M,N)(\num{1}) \red N$.
 \end{lem}
 
 \begin{proof}
-First, define the lambda term $K$ by 
+First, define the lambda term $K$ by
 \[
 K(y) = \lambd[x][y].
 \]
@@ -63,7 +63,7 @@ Now define $D(x,y,z)$ by $D(x,y,z) = z (K(y))x$. Then we have
 D(M,N,\num 0) & \red \num 0 (K(N)) M \red M \text{ and}\\
 D(M,N,\num 1) & \red \num 1 (K(N)) M \red K(N) M \red N,
 \end{align*}
-as required. 
+as required.
 \end{proof}
 
 The idea is that $D(M,N)$ represents the pair $\tuple{M, N}$, and if
@@ -85,7 +85,7 @@ F(\num{n+1}) & \equiv H(\num{n}, F(\num{n}))
 for every natural number~$n$. The idea is roughly to compute sequences
 of \emph{pairs}
 \[
-\tuple{\num 0, F(\num 0)}, \tuple{\num 1, F(\num 1)}, \dots, 
+\tuple{\num 0, F(\num 0)}, \tuple{\num 1, F(\num 1)}, \dots,
 \]
 using numerals as iterators. Notice that the first pair is just
 $\tuple{\num 0, G}$. Given a pair $\tuple{\num{n}, F(\num{n})}$, the
@@ -97,7 +97,7 @@ The details are as follows. Define $T(u)$ by
 \[
 T(u) = \tuple{S((u)_0), H((u)_0,(u)_1)}.
 \]
-Now it is easy to verify that for any number~$n$, 
+Now it is easy to verify that for any number~$n$,
 \[
 T(\tuple{\num{n}, M}) \red \tuple{\num{n+1}, H(\num{n}, M)}.
 \]
@@ -106,7 +106,7 @@ As suggested above, given $G$ and $H$, define~$F(u)$ by
 F(u) = (u(T,\tuple{\num 0, G}))_1.
 \]
 In other words, on input~$\num{n}$, $F$ iterates $T$ $n$ times on
-$\tuple{\num 0, G}$, and then returns the second component.  To start
+$\tuple{\num 0, G}$, and then returns the second component. To start
 with, we have
 \begin{enumerate}
 \item $\num{0} (T, \tuple{\num 0, G}) \equiv \tuple{\num{0}, G}$
@@ -129,7 +129,7 @@ F(\num{n+1}) & \red (\num{n+1}(T, \tuple{\num 0, G}))_1 \\
 Here we have used the induction hypothesis on the second-to-last
 line. For the first clause, we have
 \begin{align*}
-\num{n+1} (T, \tuple{\num 0, G}) & 
+\num{n+1} (T, \tuple{\num 0, G}) &
 \equiv T(\num{n} (T, \tuple{\num 0, G})) \\
 & \equiv T( \tuple{\num{n}, F(\num{n})}) \\
 & \equiv \tuple{\num{n+1}, H(\num{n}, F(\num{n}))} \\

--- a/computability/lambda-calculus/reduction.tex
+++ b/computability/lambda-calculus/reduction.tex
@@ -25,7 +25,7 @@ also $M[x/N]$. Beware!
 
 Intuitively, $(\lambd[x][M])N$ and $\Subst{M}{N}{x}$ have the same
 meaning; the act of replacing the first term by the second is called
-$\beta$-conversion.  More generally, if it is possible convert a
+$\beta$-conversion. More generally, if it is possible convert a
 term $P$ to~$P'$ by $\beta$-conversion of some subterm, one says
 \emph{$P$ $\beta$-reduces to $P'$ in one step}. If $P$ can be
 converted to~$P'$ with any number of one-step reductions (possibly

--- a/computability/lambda-calculus/syntax.tex
+++ b/computability/lambda-calculus/syntax.tex
@@ -10,7 +10,7 @@
 \olsection{The Syntax of the Lambda Calculus}
 
 One starts with a sequence of variables $x$, $y$, $z$,~\dots and some
-constant symbols $a$, $b$, $c$,~\dots.  The set of terms is defined
+constant symbols $a$, $b$, $c$,~\dots. The set of terms is defined
 inductively, as follows:
 \begin{enumerate}
 \item Each variable is a term.
@@ -56,7 +56,7 @@ Variables that are in the scope of a $\lambd$ are called ``bound'',
 while others are called ``free.'' There are no free variables in the
 previous example; but in
 \[
-(\lambd[z][yz])x 
+(\lambd[z][yz])x
 \]
 $y$ and $x$ are free, and $z$ is bound.
 

--- a/computability/recursive-functions/bounded-minimization.tex
+++ b/computability/recursive-functions/bounded-minimization.tex
@@ -31,7 +31,7 @@ $m_R(y+1, \vec{z}) = y$. (c) There is no $x < y+1$ such that $R(x,
 \vec{z})$, then $m_R(y+1,\vec{z}) = 0$. So,
 \begin{align*}
 m_R(0, \vec{z}) & = 0\\
-m_R(y+1, \vec{z}) & = 
+m_R(y+1, \vec{z}) & =
 \begin{cases}
 m_R(y, \vec{z}) & \text{if $\lexists[x < y][R(x, \vec{z})]$} \\
 y & \text{otherwise, provided $R(y, \vec{z})$}\\
@@ -71,7 +71,7 @@ x \mid y \defiff \lexists[z \leq y][(x \cdot z) = y].
 \item The function $\fn{nextPrime(x)}$, which returns the first prime
   number larger than $x$, defined by
 \[
-  \fn{nextPrime(x)} = 
+  \fn{nextPrime(x)} =
   \bmin{y \leq x\fac+1}{(y > x \land \fn{Prime}(y))}
 \]
 Here we are relying on Euclid's proof of the fact that there is always

--- a/computability/recursive-functions/examples.tex
+++ b/computability/recursive-functions/examples.tex
@@ -30,12 +30,12 @@ Here are some examples of primitive recursive functions:
 \fn{pred}(0) = 0, \quad \fn{pred}(x+1) = x
 \]
 
-\item Truncated subtraction, $x \tsub y$, defined by 
+\item Truncated subtraction, $x \tsub y$, defined by
 \[
 x \tsub 0 = x, \quad x \tsub (y+1) = \fn{pred}(x \tsub y)
 \]
 
-\item Maximum, $\fn{max}(x,y)$, defined by 
+\item Maximum, $\fn{max}(x,y)$, defined by
 \[
 \fn{max}(x,y) \defis x + (y \tsub x)
 \]
@@ -54,7 +54,7 @@ Show that \[f(x, y) =
 \begin{prob}
 Show that $d(x, y) = \lfloor x/y \rfloor$ (i.e., division, where you
 disregard everything after the decimal point) is primitive
-recursive. When $y = 0$, we stipulate $d(x, y) = 0$.  Give an explicit
+recursive. When $y = 0$, we stipulate $d(x, y) = 0$. Give an explicit
 definifion of $d$ using primitive recursion and composition. You will
 have detour through an axiliary function---you cannot use recursion on
 the arguments $x$ or $y$ themselves.
@@ -64,12 +64,12 @@ The set of primitive recursive functions is further closed under the
 following two operations:
 \begin{enumerate}
 \item Finite sums: if $f(x,\vec z)$ is primitive recursive, then so is the
-function 
+function
 \[
 g(y,\vec z) \defis \sum_{x = 0}^y f(x,\vec z).
 \]
 \item Finite products: if $f(x,\vec z)$ is primitive recursive, then so is the
-function 
+function
 \[
 h(y,\vec z) \defis \prod_{x = 0}^y f(x,\vec z).
 \]

--- a/computability/recursive-functions/halting-problem.tex
+++ b/computability/recursive-functions/halting-problem.tex
@@ -16,7 +16,7 @@ halts, i.e., produces a result.  Famously, Alan Turing proved that
 this problem itself cannot be solved by a computable function, i.e.,
 the function
 \[
-h(e, n) = 
+h(e, n) =
 \begin{cases}
 1 & \text{if computation $e$ halts on input $n$}\\
 0 & \text{otherwise,}
@@ -38,7 +38,7 @@ f(x)$ for all~$x \in \Nat$.  In fact, for each such $f$ there is not
 just one, but infinitely many such~$e$.  The \emph{halting function}~$h$
 is defined by
 \[
-h(e, x) = 
+h(e, x) =
 \begin{cases}
 1 & \text{if $\cfind{e}(x) \defined$}\\
 0 & \text{otherwise.}
@@ -56,7 +56,7 @@ The halting function~$h$ is not partial recursive.
 If $h$
 were partial recursive, we could define
 \[
-d(y) = 
+d(y) =
 \begin{cases}
 1 & \text{if $h(y, y) = 0$}\\
 \umin{x}{x \neq x} & \text{otherwise.}

--- a/computability/recursive-functions/non-pr-functions.tex
+++ b/computability/recursive-functions/non-pr-functions.tex
@@ -16,15 +16,15 @@ $f_0$, $f_1$, $f_2$,~\dots such that we can effectively compute the value of
 $f_x$ on input $y$; in other words, the function $g(x,y)$, defined by
 \[
 g(x,y) = f_x(y)
-\] 
-is computable. But then so is the function 
+\]
+is computable. But then so is the function
 \begin{eqnarray*}
 h(x) & = & g(x,x) + 1 \\
 & = & f_x(x) +1.
 \end{eqnarray*}
 For each primitive recursive function $f_i$, the value of $h$ and
 $f_i$ differ at $i$. So $h$ is computable, but not primitive
-recursive; and one can say the same about $g$.  This is a an
+recursive; and one can say the same about $g$. This is a an
 ``effective'' version of Cantor's diagonalization argument.
 
 One can provide more explicit examples of computable functions that
@@ -77,7 +77,7 @@ $f_x$ refers to the enumeration we have just described. How do we know
 that $g(x,y)$ is computable? Intuitively, this is clear: to compute
 $g(x,y)$, first ``unpack'' $x$, and see if it a notation for a unary
 function; if it is, compute the value of that function on input
-$y$. 
+$y$.
 
 \begin<TMs>{digress}
 You may already be convinced that (with some work!) one can write a

--- a/computability/recursive-functions/normal-form.tex
+++ b/computability/recursive-functions/normal-form.tex
@@ -17,7 +17,7 @@ partial recursive function, then for some~$e$,
 \[
 f(x) \simeq U(\umin{s}{T(e, x, s)})
 \]
-for every $x$. 
+for every $x$.
 \end{thm}
 
 \begin{explain}
@@ -38,7 +38,7 @@ use the numbers $e$ as ``names'' of partial recursive functions, and
 write $\cfind{e}$ for the function $f$ defined by the equation in the
 theorem.  Note that any partial recursive function can have more than
 one index---in fact, every partial recursive function has infinitely
-many indices.  
+many indices.
 \end{explain}
 \end{document}
 

--- a/computability/recursive-functions/partial-functions.tex
+++ b/computability/recursive-functions/partial-functions.tex
@@ -12,7 +12,7 @@
 
 To motivate the definition of the recursive functions, note that our
 proof that there are computable functions that are not primitive
-recursive actually establishes much more. The argument was very
+recursive actually establishes much more. The argument was
 simple: all we used was the fact was that it is possible to enumerate
 functions $f_0,f_1,\dots$ such that, as a function of $x$ and $y$,
 $f_x(y)$ is computable. So the argument applies to \emph{any class of
@@ -68,7 +68,7 @@ numbers, define $\mu x \; f(x,\vec z)$ to be
 \begin{quote}
   the least $x$ such that $f(0,\vec z), f(1,\vec z), \dots, f(x,\vec
   z)$ are all defined, and $f(x,\vec z) = 0$, if such an $x$ exists
-\end{quote} 
+\end{quote}
 with the understanding that $\mu x \; f(x,\vec z)$ is undefined
 otherwise. This defines $\mu x \; f(x,\vec z)$ uniquely.
 
@@ -106,7 +106,7 @@ Of course, some of the partial recursive functions will happen to be
 total, i.e., defined for every argument.
 
 \begin{defn}
-\ollabel{defn:recursive-fn} 
+\ollabel{defn:recursive-fn}
 The set of \emph{recursive functions} is
 the set of partial recursive functions that are total.
 \end{defn}

--- a/computability/recursive-functions/pr-functions-computable.tex
+++ b/computability/recursive-functions/pr-functions-computable.tex
@@ -21,12 +21,12 @@ $1 = 0 + 1$ and so $h(1, \vec z)$ is just
 \[
  g(0, h(0, \vec z), \vec z) =  g(0, f(\vec z), \vec z).
 \]
-We can go on in this way and  compute 
+We can go on in this way and  compute
 \begin{align*}
 h(2, \vec z) & = g(1, g(0, f(\vec z), \vec z), \vec z)\\
 h(3, \vec z) & = g(2, g(1, g(0, f(\vec z), \vec z), \vec z), \vec z)\\
 h(4, \vec z) & = g(3, g(2, g(1, g(0, f(\vec z), \vec z), \vec z), \vec z), \vec z)\\
-& \vdots 
+& \vdots
 \end{align*}
 Thus, to compute $h(x, \vec z)$ in general, successively compute $h(0,
 \vec z)$, $h(1, \vec z)$, \dots, until we reach $h(x, \vec z)$.

--- a/computability/recursive-functions/pr-relations.tex
+++ b/computability/recursive-functions/pr-relations.tex
@@ -17,11 +17,11 @@ function,
 \Char{R}(\vec x) = \left\{
   \begin{array}{ll}
   1 & \mbox{if $R(\vec x)$} \\
-  0 & \mbox{otherwise} 
+  0 & \mbox{otherwise}
   \end{array}
 \right.
 \]
-is primitive recursive. 
+is primitive recursive.
 \end{defn}
 
 In other words, when one speaks of a primitive
@@ -30,7 +30,7 @@ form $\Char{R}(\vec x) = 1$, where $\Char{R}$ is a primitive recursive
 function which, on any input, returns either 1 or 0. For example, the
 relation $\fn{Zero}(x)$, which holds if and only if $x = 0$,
 corresponds to the function $\Char{\fn{Zero}}$, defined using primitive
-recursion by 
+recursion by
 \[
 \Char{\fn{Zero}}(0) = 1, \quad \Char{\fn{Zero}}(x+1) = 0.
 \]
@@ -56,14 +56,14 @@ are all primitive recursive, if $P$ and $Q$ are.
 One can also define relations using bounded quantification:
 \begin{enumerate}
 \item Bounded universal quantification: if $R(x, \vec z)$ is a
-primitive recursive relation, then so is the relation 
+primitive recursive relation, then so is the relation
 \[
 \lforall[x < y][R(x, \vec z)]
 \]
 which holds if and only if $R(x,\vec z)$ holds for every $x$ less than
 $y$.
 \item Bounded existential quantification: if $R(x, \vec z)$ is a
-primitive recursive relation, then so is 
+primitive recursive relation, then so is
 \[
 \lexists[x < y][R(x, \vec z)].
 \]
@@ -115,12 +115,12 @@ f(\vec x) = \left\{\begin{array}{ll}
 \]
 is also primitive recursive.
 \end{enumerate}
-When $m = 1$, this is just the the function defined by 
+When $m = 1$, this is just the function defined by
 \[
 f(\vec x) = \fn{cond}(\Char{\lnot R_0}(\vec x),g_0(\vec x),g_1(\vec
  x)).
 \]
 For $m$ greater than $1$, one can just compose definitions of this
-form. 
+form.
 
 \end{document}

--- a/computability/recursive-functions/primitive-recursion.tex
+++ b/computability/recursive-functions/primitive-recursion.tex
@@ -47,7 +47,7 @@ of \emph{primitive recursive functions} is the set of functions from
 $\Nat$ to $\Nat$ that you get if you start with $0$ and the successor
 function, $S(x) = x+1$, and iterate the two operations above,
 primitive recursion and composition. The idea is that primitive
-recursive functions are defined in a very straightforward and explicit
+recursive functions are defined in a straightforward and explicit
 way, so that it is intuitively clear that each one can be computed
 using finite means.
 \end{explain}
@@ -104,7 +104,7 @@ following:
 Put more concisely, the set of primitive recursive functions is the
 smallest set containing the constant 0, the successor function,
 and projection functions, and closed under composition and primitive
-recursion. 
+recursion.
 
 Another way of describing the set of primitive recursive functions
 keeps track of the ``stage'' at which a function enters the set. Let

--- a/computability/recursive-functions/sequences.tex
+++ b/computability/recursive-functions/sequences.tex
@@ -11,7 +11,7 @@
 
 The set of primitive recursive functions is
 remarkably robust. But we will be able to do even more once we have
-developed an adequate means of handling \emph{sequences}.  We will
+developed an adequate means of handling \emph{sequences}. We will
 identify finite sequences of natural numbers with natural numbers in
 the following way: the sequence $\langle a_0, a_1, a_2, \dots, a_k \rangle$
 corresponds to the number
@@ -28,8 +28,8 @@ Let us define the following functions:
 \begin{enumerate}
 \item $\len{s}$, which returns the length of the sequence $s$:
 \[
-\len{s} = 
-\begin{cases} 
+\len{s} =
+\begin{cases}
 0 & \text{if $s = 0$ or $s = 1$} \\
 \bmin{i < s}{(p_i \mid s \land \lforall[j < s][(j > i \lif
     p_j \mathrel{\not\mid} s)])}+1 & \text{otherwise}
@@ -41,7 +41,7 @@ acceptable bound.
 \item $\fn{append}(s,a)$, which returns the result of appending $a$ to
   the sequence $s$:
 \[
-\fn{append}(s,a) = 
+\fn{append}(s,a) =
 \begin{cases}
   2^{a+1} & \text{if $s = 0$ or $s = 1$} \\
 s \cdot p_{\len{s}}^{a+1} & \text{otherwise}
@@ -51,7 +51,7 @@ s \cdot p_{\len{s}}^{a+1} & \text{otherwise}
   (where the initial element is called the $0$th), or $0$ if $i$ is
   greater than or equal to the length of $s$:
 \[
-\fn{element}(s,i) = 
+\fn{element}(s,i) =
 \begin{cases}
   0 & \mbox{if $i \geq \len{s}$} \\
   \fn{min} \; {j < s} \; (p_i^{j+2} \not | s) - 1 & \text{otherwise}
@@ -60,7 +60,7 @@ s \cdot p_{\len{s}}^{a+1} & \text{otherwise}
 \end{enumerate}
 
 Instead of using the official names for the functions defined above,
-we introduce a more compact notation.  We will use $(s)_i$ instead of
+we introduce a more compact notation. We will use $(s)_i$ instead of
 $\fn{element}(s,i)$, and $\tuple{s_0, \dots, s_k}$ to abbreviate
 $\fn{append}(\fn{append}(\dots \fn{append}(\emptyseq,s_0)
 \dots),s_k)$. Note that if $s$ has length~$k$, the elements of $s$ are
@@ -89,7 +89,7 @@ follows:
 \item $\fn{hconcat}(s,t,0) = s$
 \item $\fn{hconcat}(s,t,n+1) = \fn{append}(\fn{hconcat}(s,t,n),(t)_n)$
 \end{enumerate}
-Then we can define $\fn{concat}$ by 
+Then we can define $\fn{concat}$ by
 \[
 \fn{concat}(s,t) = \fn{hconcat}(s,t,\len{t}).
 \]

--- a/examples/open-logic-enderton-config.sty
+++ b/examples/open-logic-enderton-config.sty
@@ -12,11 +12,11 @@
 \DeclareDocumentCommand \Sat { t{/} m m o } {
   \IfBooleanTF{#1}{
     % negated
-    \IfNoValueTF {#4} 
+    \IfNoValueTF {#4}
         { \not\models_{\Struct #2} #3 }
         { \not\models_{\Struct #2} #3 [#4]}}{
     % not negated
-    \IfNoValueTF {#4} 
+    \IfNoValueTF {#4}
         { \models_{\Struct #2} #3 }
         { \models_{\Struct #2} #3 [#4] }}
 }

--- a/first-order-logic/beyond/higher-order-logic.tex
+++ b/first-order-logic/beyond/higher-order-logic.tex
@@ -39,7 +39,7 @@ that is, higher-type functions that take functions to numbers.
 
 As in the case of second-order logic, one can think of higher-order
 logic as a kind of many-sorted logic, where there is a sort for each
-type of object we want to consider.  But it is usually clearer just to
+type of object we want to consider. But it is usually clearer just to
 define the syntax of higher-type logic from the ground up. For
 example, we can define a set of finite types inductively, as follows:
 \begin{enumerate}
@@ -52,7 +52,7 @@ example, we can define a set of finite types inductively, as follows:
 Intuitively, $\Nat$ denotes the type of the natural numbers,
 $\sigma \to \tau$ denotes the type of functions from $\sigma$ to
 $\tau$, and $\sigma \times \tau$ denotes the type of pairs of objects,
-one from $\sigma$ and one from $\tau$.  We can then define a set of
+one from $\sigma$ and one from $\tau$. We can then define a set of
 terms inductively, as follows:
 \begin{enumerate}
 \item For each type $\sigma$, there is a stock of variables $x$, $y$,

--- a/first-order-logic/beyond/introduction.tex
+++ b/first-order-logic/beyond/introduction.tex
@@ -11,7 +11,7 @@
 \olsection{Overview}
 
 First-order logic is not the only system of logic of interest: there
-are many extensions and variations of first-order logic.  A logic
+are many extensions and variations of first-order logic. A logic
 typically consists of the formal specification of a language, usually,
 but not always, a deductive system, and usually, but not always, an
 intended semantics. But the technical use of the term raises an
@@ -29,7 +29,7 @@ true independent of the interpretation of the nonlogical terms, true
 by virtue of their form, or true by linguistic convention; and each of
 these conceptions requires a good deal of clarification. Even if one
 restricts one's attention to the kind of logic used in mathematical,
-there is little agreement as to its scope.  For example, in the
+there is little agreement as to its scope. For example, in the
 \textit{Principia Mathematica}, Russell and Whitehead tried to develop
 mathematics on the basis of logic, in the {\em logicist} tradition
 begun by Frege. Their system of logic was a form of higher-type logic

--- a/first-order-logic/beyond/intuitionistic-logic.tex
+++ b/first-order-logic/beyond/intuitionistic-logic.tex
@@ -162,7 +162,7 @@ the theorem above provides some useful information:
 
 \begin{thm}
 If $\Gamma$ proves $!A$ classically, $\Gamma^N$ proves $!A^N$
-intuitionistically. 
+intuitionistically.
 \end{thm}
 
 In other words, if $!A$ is provable from some hypotheses classically,
@@ -170,7 +170,7 @@ then $!A^N$ is provable from their double-negation translations.
 
 To show that a sentence or propositional !!{formula} is intuitionistically
 valid, all you have to do is provide a proof. But how can you show
-that it is not valid?  For that purpose, we need a semantics
+that it is not valid? For that purpose, we need a semantics
 that is sound, and preferrably complete. A semantics
 due to Kripke nicely fits the bill.
 
@@ -204,7 +204,7 @@ inductively, as follows:
   assigned to~$p$.
 \item $\mSat/{P}{\lfalse}[p]$.
 \item $\mSat{P}{(!A \land !B)}[p]$ iff $\mSat{P}{!A}[p]$ and $\mSat{P}{!B}[p]$.
-\item $\mSat{P}{(!A \lor !B)}[p]$ iff $\mSat{P}{!A}[p]$ or $\mSat{P}{!B}[p]$. 
+\item $\mSat{P}{(!A \lor !B)}[p]$ iff $\mSat{P}{!A}[p]$ or $\mSat{P}{!B}[p]$.
 \item $\mSat{P}{(!A \lif !B)}[p]$ iff, whenever $q \geq p$ and
   $\mSat{P}{!A}[q]$, then $\mSat{P}{!B}[q]$.
 \end{enumerate}

--- a/first-order-logic/beyond/modal-logics.tex
+++ b/first-order-logic/beyond/modal-logics.tex
@@ -44,7 +44,7 @@ in mind. Rather than restricting to partial orders, more generally one
 has a set of ``possible worlds,'' $P$, and a binary ``accessibility''
 relation $\Atom{R}{x,y}$ between worlds. Intuitively, $\Atom{R}{p,q}$
 asserts that the world~$q$ is compatible with~$p$; i.e., if we are
-``in'' world~$p$, we have to entertain the the possibility that the
+``in'' world~$p$, we have to entertain the possibility that the
 world could have been like~$q$.
 
 Modal logic is sometimes called an ``intensional'' logic, as opposed

--- a/first-order-logic/beyond/other-logics.tex
+++ b/first-order-logic/beyond/other-logics.tex
@@ -21,8 +21,8 @@ properties.
 
 Recent decades have witnessed a veritable explosion of formal logics.
 Fuzzy logic is designed to model reasoning about vague
-properties.  Probabilistic logic is designed to model
-reasoning about uncertainty.  Default logics and nonmonotonic logics
+properties. Probabilistic logic is designed to model
+reasoning about uncertainty. Default logics and nonmonotonic logics
 are designed to model defeasible forms of reasoning, which is
 to say, ``reasonable'' inferences that can later be overturned in the
 face of new information. There are epistemic logics, designed to

--- a/first-order-logic/beyond/second-order-logic.tex
+++ b/first-order-logic/beyond/second-order-logic.tex
@@ -65,7 +65,7 @@ $R$ is not a free variable. (Exercise: show that if $R$ is allowed to
 occur in~$!A$, this schema is inconsistent!)
 
 When logicians refer to the ``axioms of second-order logic'' they
-usually mean the the minimal extension of first-order logic by
+usually mean the minimal extension of first-order logic by
 second-order quantifier rules together with the comprehension
 schema. But it is often interesting to study weaker subsystems of
 these axioms and rules. For example, note that in its full generality
@@ -105,7 +105,7 @@ logic. In terms of the proof system, one might have in mind either
 \item The ``standard'' second-order proof system, with full
   comprehension.
 \end{enumerate}
-In terms of the semantics, one might be interested in either 
+In terms of the semantics, one might be interested in either
 \begin{enumerate}
 \item The ``weak'' semantics, where a !!{structure} consists of a first-order
   part, together with a second-order part big enough to satisfy the
@@ -178,7 +178,7 @@ then define the class of infinite !!{structure}s to be the class of
   \land \lexists[y][\lforall[x][\eq/[f(x)][y]]])].
 \]
 The negation of this sentence then defines the class of finite
-!!{structure}s. 
+!!{structure}s.
 
 In addition, one can define the class of well-orderings, by adding the
 following to the definition of a linear ordering:

--- a/first-order-logic/completeness/compactness.tex
+++ b/first-order-logic/completeness/compactness.tex
@@ -15,18 +15,18 @@
 \end{defn}
 
 \begin{thm}[Compactness Theorem]
-\ollabel{thm:compactness} 
+\ollabel{thm:compactness}
 The following hold for any sentences $\Gamma$ and $!A$:
 \begin{enumerate}
   \item $\Gamma \Entails !A$ iff there is a finite $\Gamma_0
     \subseteq \Gamma$ such that $\Gamma_0 \Entails !A$.
   \item $\Gamma$ is satisfiable if and only if it is finitely
-    satisfiable. 
+    satisfiable.
 \end{enumerate}
 \end{thm}
 
 \begin{proof}
-We prove (2). If $\Gamma$ is satisfiable, then there is a
+We prove (2).  If $\Gamma$ is satisfiable, then there is a
 !!{structure}~$\Struct{M}$ such that $\Sat{M}{!A}$ for all $!A \in
 \Gamma$.  Of course, this $\Struct M$ also satisfies every finite
 subset of~$\Gamma$, so $\Gamma$ is finitely satisfiable.
@@ -34,7 +34,7 @@ subset of~$\Gamma$, so $\Gamma$ is finitely satisfiable.
 Now suppose that $\Gamma$ is finitely satisfiable.  Then every finite
 subset~$\Gamma_0 \subseteq \Gamma$ is satisfiable.  By soundness,
 every finite subset is consistent.  Then $\Gamma$ itself must be
-consistent. For assume it is not, i.e., $\Gamma \Proves \bot$.  But
+consistent.  For assume it is not, i.e., $\Gamma \Proves \bot$.  But
 !!{derivation}s are finite, and so already some finite
 subset~$\Gamma_0 \subseteq \Gamma$ must be inconsistent
 (cf.~\olref[seq][ptn]{prop:proves-compact}).  But we just showed they

--- a/first-order-logic/completeness/completeness-thm.tex
+++ b/first-order-logic/completeness/completeness-thm.tex
@@ -10,7 +10,7 @@
 \olsection{The Completeness Theorem}
 
 \begin{thm}[Completeness Theorem]
-\ollabel{thm:completeness} 
+\ollabel{thm:completeness}
 Let $\Gamma$ be a set of !!{sentence}s.  If
 $\Gamma$ is consistent, it is satisfiable.
 \end{thm}
@@ -23,7 +23,7 @@ saturated.  If $\Gamma$ does not contain~$\eq$, then by
 From this it follows in particular that for all $!A \in \Gamma$,
 $\Sat{M(\Gamma^*)}{!A}$, so $\Gamma$ is satisfiable.  If $\Gamma$ does
 contain~$\eq$, then by \olref[ide]{lem:truth}, $\Sat{M/_\approx}{!A}$
-iff $!A \in \Gamma^*$ for all sentences~$!A$. In particular,
+iff $!A \in \Gamma^*$ for all sentences~$!A$.  In particular,
 $\Sat{M/_\approx}{!A}$ for all $!A \in \Gamma$, so $\Gamma$ is
 satisfiable.
 \end{proof}
@@ -36,18 +36,18 @@ $\Gamma \Proves !A$.
 
 \begin{proof}
 Note that the $\Gamma$'s in \olref{cor:completeness} and
-\olref{thm:completeness} are universally quantified. To make sure we
+\olref{thm:completeness} are universally quantified.  To make sure we
 do not confuse ourselves, let us restate \olref{thm:completeness}
 using a different variable: for any set of sentences~$\Delta$, if
 $\Delta$ is consistent, it is satisfiable.  By contraposition, if
-$\Delta$ is not satisfiable, then $\Delta$ is inconsistent. We will
+$\Delta$ is not satisfiable, then $\Delta$ is inconsistent.  We will
 use this to prove the corollary.
 
-Suppose that $\Gamma \Entails !A$. Then $\Gamma \cup \{\lnot !A\}$ is
-unsatisfiable by \olref[syn][sem]{prop:entails-unsat}. Taking $\Gamma
+Suppose that $\Gamma \Entails !A$.  Then $\Gamma \cup \{\lnot !A\}$ is
+unsatisfiable by \olref[syn][sem]{prop:entails-unsat}.  Taking $\Gamma
 \cup \{\lnot !A\}$ as our $\Delta$, the previous version of
 \olref{thm:completeness} gives us that $\Gamma \cup \{\lnot !A\}$ is
-inconsistent. By \olref[seq][ptn]{prop:prov-incons}, $\Gamma \Proves
+inconsistent.  By \olref[seq][ptn]{prop:prov-incons}, $\Gamma \Proves
 !A$.
 \end{proof}
 
@@ -64,7 +64,7 @@ the rules of $\Log{LK}$ were necessary to prove completeness?  Are any
 of these rules not used anywhere in the proof?  In order to answer
 these questions, make a list or diagram that shows which of the rules
 of $\Log{LK}$ were used in which results that lead up to the proof of
-\olref[fol][com][cth]{thm:completeness}. Be sure to note any tacit
+\olref[fol][com][cth]{thm:completeness}.  Be sure to note any tacit
 uses of rules in these proofs.
 \end{prob}
 

--- a/first-order-logic/completeness/construction-of-model.tex
+++ b/first-order-logic/completeness/construction-of-model.tex
@@ -17,7 +17,7 @@ language~$\Lang L$ without~$\eq$.
 \begin{defn}
 \ollabel{termmodel}
 Let $\Gamma^*$ be a maximally consistent, saturated set of !!{sentence}s
-in a language~$\Lang L$.  The \emph{term model}~$\Struct M(\Gamma^*)$
+in a language~$\Lang L$. The \emph{term model}~$\Struct M(\Gamma^*)$
 of $\Gamma^*$ is the !!{structure} defined as follows:
 \begin{enumerate}
 \item The !!{domain}~$\Domain{M(\Gamma^*)}$ is the set of all closed terms
@@ -49,16 +49,16 @@ We prove both directions simultaneously, and by induction on $!A$.
   definition of satisfaction) iff $R(t_1, \dots, t_n) \in \Gamma^*$
   (the construction of $\Struct M(\Gamma^*)$.}
 
-\tagitem{prvNot}{% 
+\tagitem{prvNot}{%
 \indcase{!A}{\lnot !B}{$\Sat{M(\Gamma^*)}{\indfrm}$ iff
-  $\Sat/{M(\Gamma^*)}{!B}$ (by definition of satisfaction).  By
+  $\Sat/{M(\Gamma^*)}{!B}$ (by definition of satisfaction). By
   induction hypothesis, $\Sat/{M(\Gamma^*)}{!B}$ iff $!B \notin
   \Gamma^*$. By \olref[mcs]{prop:mcs}\olref[mcs]{prop:mcs-either-or},
   $\lnot !B \in \Gamma^*$ if $!B \notin \Gamma^*$; and $\lnot !B
   \notin \Gamma^*$ if $!B \in \Gamma^*$ since $\Gamma^*$ is
   consistent.}}{}
 
-\tagitem{prvAnd}{% 
+\tagitem{prvAnd}{%
 \iftag{probAnd}{%
 \indcase!{!A}{!B \land !C}{}}{%
 \indcase{!A}{!B \land !C}{$\Sat{M(\Gamma^*)}{\indfrm}$ iff we have
@@ -68,7 +68,7 @@ We prove both directions simultaneously, and by induction on $!A$.
   \olref[mcs]{prop:mcs}\olref[mcs]{prop:mcs-and}, this is the case
   iff $(!B \land !C) \in \Gamma^*$.}}}{}
 
-\tagitem{prvOr}{% 
+\tagitem{prvOr}{%
 \iftag{probOr}{%
 \indcase!{!A}{!B \lor !C}{}}{%
 \indcase{!A}{!B \lor !C}{$\Sat{M(\Gamma^*)}{\indfrm}$ iff at
@@ -100,11 +100,11 @@ We prove both directions simultaneously, and by induction on $!A$.
       {$(\lnot\lforall[x][!B(x)] \lif \lnot !B(c)) \in \Gamma^*$}
   for some $c$, so by
   \olref[mcs]{prop:mcs}\olref[mcs]{prop:mcs-prov-in}, $\lnot !B(c) \in
-  \Gamma^*$.  Since $\Gamma^*$ is consistent, $!B(c) \notin
+  \Gamma^*$. Since $\Gamma^*$ is consistent, $!B(c) \notin
   \Gamma^*$. By induction hypothesis, $\Sat/{M(\Gamma^*)}{!B(c)}$.
   Therefore, if $s'$ is the variable assignment such that $s(x)=c$,
   then $\Sat/{M(\Gamma^*)}{!B(x)}[s']$, contradicting the earlier
-  result that $\Sat{M(\Gamma^*)}{!B(x)}[s]$ for all~$s$.  Thus, we
+  result that $\Sat{M(\Gamma^*)}{!B(x)}[s]$ for all~$s$. Thus, we
   have $\indfrm \in \Gamma^*$.
 
 Conversely, suppose that $\lforall[x][!B(x)] \in \Gamma^*$. By
@@ -123,8 +123,8 @@ $\Sat{M(\Gamma^*)}{\indfrm}$.}}}{}
   some variable assignment $s$, $\Sat{M(\Gamma^*)}{!B(x)}[s]$. The
   value $s(x)$ is some term~$t \in \Domain{M(\Gamma^*)}$. Thus,
     $\Sat{M(\Gamma^*)}{!B(t)}$, and by our induction hypothesis,
-    $!B(t) \in \Gamma^*$.  By \olref[seq][prv]{thm:provability-quantifiers}
-    we have $\Gamma^* \Proves \lexists[x][!B(x)]$.  Then, by
+    $!B(t) \in \Gamma^*$. By \olref[seq][prv]{thm:provability-quantifiers}
+    we have $\Gamma^* \Proves \lexists[x][!B(x)]$. Then, by
     \olref[mcs]{prop:mcs}\olref[mcs]{prop:mcs-prov-in}, we can
     conclude that $\indfrm \in \Gamma^*$.
 

--- a/first-order-logic/completeness/downward-ls.tex
+++ b/first-order-logic/completeness/downward-ls.tex
@@ -9,7 +9,7 @@
 \olfileid{fol}{com}{dls}
 \olsection{The L\"owenheim-Skolem Theorem}
 
-\begin{thm} 
+\begin{thm}
 \ollabel{downward-ls} If $\Gamma$ is consistent then it has
 !!a{denumerable} model, i.e., it is satisfiable in a !!{structure}
 whose domain is either finite or infinite but !!{enumerable}.
@@ -22,7 +22,7 @@ cardinality is bounded by that of the set of the terms of the language
 $\Lang L$. So $\Struct M$ is at most !!{denumerable}.
 \end{proof}
 
-\begin{thm} 
+\begin{thm}
 \ollabel{noidentity-ls} If $\Gamma$ is consistent set of !!{sentence}s
 in the language of first-order logic without identity, then it has
 !!a{denumerable} model, i.e., it is satisfiable in a !!{structure}

--- a/first-order-logic/completeness/henkin-expansions.tex
+++ b/first-order-logic/completeness/henkin-expansions.tex
@@ -17,7 +17,7 @@ all the quantified !!{formula}s in~$\Gamma$ true.  In order to
 guarantee this, we use a trick due to Leon Henkin.  In essence, the
 trick consists in expanding the language by infinitely many constants
 and adding, for each !!{formula} with one free !!{variable} $!A(x)$ a
-formula of the form 
+formula of the form
 \iftag{prvEx}
       {$\lexists[x][!A] \lif !A(c)$}
       {$\lnot\lforall[x][!A] \lif \lnot !A(c)$},
@@ -72,10 +72,10 @@ consistent set~$\Gamma'$.
 \begin{proof}
 Given a consistent set of sentences~$\Gamma$ in a language~$\Lang{L}$,
 expand the language by adding !!a{denumerable} set of new
-!!{constant}s to form~$\Lang{L'}$. By the previous Lemma, $\Gamma$ is still
-consistent in the richer language. Further, let $!D_i$ be as in the
+!!{constant}s to form~$\Lang{L'}$.  By the previous Lemma, $\Gamma$ is still
+consistent in the richer language.  Further, let $!D_i$ be as in the
 previous definition: then $\Gamma \cup \{!D_1, !D_2, \dots\}$ is
-saturated by construction. Let
+saturated by construction.  Let
 \begin{align*}
 \Gamma_0 & = \Gamma \\
 \Gamma_{n+1} & = \Gamma_n \cup \{!D_{n+1} \}
@@ -88,10 +88,10 @@ set~$\Gamma_n$ is consistent.
 The induction basis is simply the claim that $\Gamma_0 = \Gamma$ is
 consistent, which is the hypothesis of the theorem.  For the induction
 step, suppose that $\Gamma_{n-1}$ is consistent but $\Gamma_n =
-\Gamma_{n-1} \cup \{!D_n\}$ is inconsistent. Recall that $!D_n$~is
+\Gamma_{n-1} \cup \{!D_n\}$ is inconsistent.  Recall that $!D_n$~is
 \iftag{prvEx}
 {$\lexists[x_{n}][!A_{n}(x_n)] \lif !A_{n}(c_{n})$}
-{$\lnot\lforall[x_{n}][!A_{n}(x_n)] \lif \lnot !A_{n}(c_{n})$}. 
+{$\lnot\lforall[x_{n}][!A_{n}(x_n)] \lif \lnot !A_{n}(c_{n})$}.
 where $!A(x)$ is a !!{formula} of $\Lang{L'}$ with only the
 variable~$x_n$ free and not containing any !!{constant}s~$c_i$ where
 $i \ge n$.
@@ -110,24 +110,24 @@ If $\Gamma_{n-1} \cup \{!D_n\}$ is inconsistent, then $\Gamma_{n-1}
 \Gamma_{n-1} \Proves !A_n(c_n)
 \]}
 Here $c_n$ does not occur in $\Gamma_{n-1}$ or $!A_n(x_n)$ (remember,
-it was added only with~$!D_n$). By
+it was added only with~$!D_n$).  By
 \olref[seq][prv]{thm:strong-generalization}, from
 \iftag{prvEx}
-{$\Gamma \Proves \lnot !A_n(c_n)$} 
-{$\Gamma \Proves !A_n(c_n)$}, 
-we obtain 
+{$\Gamma \Proves \lnot !A_n(c_n)$}
+{$\Gamma \Proves !A_n(c_n)$},
+we obtain
 \iftag{prvEx}
 {$\Gamma \Proves \lforall[x_n][\lnot !A_n(x_n)]$}
 {$\Gamma \Proves \lforall[x_n][!A_n(x_n)]$}.
-Thus we have that both 
+Thus we have that both
 \iftag{prvEx}
-{$\Gamma_{n-1} \Proves \lexists[x_n][!A_n]$ and 
+{$\Gamma_{n-1} \Proves \lexists[x_n][!A_n]$ and
 $\Gamma_{n-1} \Proves \lforall[x_n][\lnot !A_n(x_n)]$}
-{$\Gamma_{n-1} \Proves \lnot\lforall[x_n][!A_n(x_n)]$ and 
+{$\Gamma_{n-1} \Proves \lnot\lforall[x_n][!A_n(x_n)]$ and
 $\Gamma_{n-1} \Proves \lforall[x_n][!A_n(x_n)]$},
-so $\Gamma$ itself is inconsistent. 
+so $\Gamma$ itself is inconsistent.
 \iftag{prvEx}
-{(Note that 
+{(Note that
 \iftag{prvAll}
 {$\lforall[x_n][\lnot !A_n(x_n)] \Proves
   \lnot\lexists[x_n][!A_n(x_n)]$}
@@ -135,7 +135,7 @@ so $\Gamma$ itself is inconsistent.
   $\lnot\lexists[x_n][\lnot\lnot !A_n(x_n)]$ and
   $\lnot\lexists[x_n][\lnot\lnot !A_n(x_n)] \Proves
   \lnot\lexists[x_n][!A_n(x_n)]$}.)}{}
-Contradiction: $\Gamma_{n-1}$ was supposed to be consistent. Hence
+Contradiction: $\Gamma_{n-1}$ was supposed to be consistent.  Hence
 $\Gamma_n \cup \{ !D_n\}$ is consistent.
 \end{proof}
 

--- a/first-order-logic/completeness/identity.tex
+++ b/first-order-logic/completeness/identity.tex
@@ -17,7 +17,7 @@ every $!A \in \Gamma^*$ which does not contain~$\eq$ (and hence all
 $!A \in \Gamma$).  It does not work, however, if $\eq$ is present.
 The reason is that $\Gamma^*$ then may contain
 !!a{sentence}~$\eq[t][t']$, but in the term model the value of any
-term is that term itself. Hence, if $t$ and $t'$ are different terms,
+term is that term itself.  Hence, if $t$ and $t'$ are different terms,
 their values in the term model---i.e., $t$ and $t'$,
 respectively---are different, and so $\eq[t][t']$ is false.  We can
 fix this, however, using a construction known as ``factoring.''
@@ -25,7 +25,7 @@ fix this, however, using a construction known as ``factoring.''
 
 \begin{defn}
 Let $\Gamma^*$ be a maximally consistent set of sentences in~$\Lang
-L$. We define the relation $\approx$ on the set of closed terms
+L$.  We define the relation $\approx$ on the set of closed terms
 of~$\Lang L$ by
 \[
 t \approx t' \text{\quad iff \quad} \eq[t][t'] \in \Gamma^*
@@ -40,15 +40,15 @@ The relation $\approx$ has the following properties:
 \item $\approx$ is symmetric.
 \item  $\approx$ is transitive.
 \item If $t \approx t'$, $f$ is !!a{function}, and $t_1$, \dots,
-  $t_{i-1}$, $t_{i+1}$, \dots, $t_n$ are terms, then 
+  $t_{i-1}$, $t_{i+1}$, \dots, $t_n$ are terms, then
 \[
-\Atom{f}{t_1,\dots, t_{i-1}, t, t_{i+1}, \dots, t_n} \approx 
+\Atom{f}{t_1,\dots, t_{i-1}, t, t_{i+1}, \dots, t_n} \approx
 \Atom{f}{t_1,\dots, t_{i-1}, t', t_{i+1}, \dots, t_n}.
 \]
 \item If $t \approx t'$, $R$ is !!a{function}, and $t_1$, \dots,
-  $t_{i-1}$, $t_{i+1}$, \dots, $t_n$ are terms, then 
+  $t_{i-1}$, $t_{i+1}$, \dots, $t_n$ are terms, then
 \[
-\Atom{R}{t_1,\dots, t_{i-1}, t, t_{i+1}, \dots, t_n} \in \Gamma^* \text{ iff } 
+\Atom{R}{t_1,\dots, t_{i-1}, t, t_{i+1}, \dots, t_n} \in \Gamma^* \text{ iff }
 \Atom{R}{t_1,\dots, t_{i-1}, t', t_{i+1}, \dots, t_n} \in \Gamma^*.
 \]
 \end{enumerate}
@@ -56,14 +56,14 @@ The relation $\approx$ has the following properties:
 
 \begin{proof}
 Since $\Gamma^*$ is maximally consistent, $\eq[t][t'] \in \Gamma^*$
-iff $\Gamma^* \Proves \eq[t][t']$. Thus it is enough to show the
+iff $\Gamma^* \Proves \eq[t][t']$.  Thus it is enough to show the
 following:
 \begin{enumerate}
 \item $\Gamma^* \Proves \eq[t][t]$ for all terms~$t$.
 \item If $\Gamma^* \Proves \eq[t][t']$ then $\Gamma^* \Proves \eq[t'][t]$.
 \item If $\Gamma^* \Proves \eq[t][t']$ and $\Gamma^* \Proves
   \eq[t'][t'']$, then $\Gamma^* \Proves \eq[t][t'']$.
-\item If $\Gamma^* \Proves \eq[t][t']$, then 
+\item If $\Gamma^* \Proves \eq[t][t']$, then
 \[
 \Gamma^* \Proves
 \eq[\Atom{f}{t_1,\dots,t_{i-1},t,t_{i+1},,\dots,t_n}][\Atom{f}{t_1,\dots,t_{i-1},t',t_{i+1},\dots,t_n}]
@@ -85,7 +85,7 @@ Complete the proof of~\olref[fol][com][ide]{prop:approx-equiv}.
 
 \begin{defn}
 Suppose $\Gamma^*$ is a maximally consistent set in a language~$\Lang
-L$, $t$ is a term, and $\approx$ as in the previous definition. Then:
+L$, $t$ is a term, and $\approx$ as in the previous definition.  Then:
 \[
 [t]_\approx = \Setabs{t'}{t'\in \Trm[L], t \approx t'}
 \]
@@ -94,7 +94,7 @@ and $\Trm[L]/_\approx = \Setabs{[t]_\approx}{t \in \Trm[L]}$.
 
 \begin{defn}
 \ollabel{defn:term-model-factor}
-Let $\Struct M = \Struct M(\Gamma^*)$ be the term model for~$\Gamma^*$. Then
+Let $\Struct M = \Struct M(\Gamma^*)$ be the term model for~$\Gamma^*$.  Then
 $\Struct M/_\approx$ is the following !!{structure}:
 \begin{enumerate}
 \item $\Domain{M/_\approx} = \Trm[L]/_\approx$.
@@ -119,7 +119,7 @@ one-place !!{predicate}, the last clause of the definition says that
 $[t]_\approx \in \Assign{R}{M/_\approx}$ iff $\Sat{M}{\Atom{R}{t}}$.
 If for some other term~$t'$ with $t \approx t'$,
 $\Sat/{M}{\Atom{R}{t}}$, then the definition would require
-$[t']_\approx \notin \Assign{R}{M/_\approx}$. If $t \approx t'$,
+$[t']_\approx \notin \Assign{R}{M/_\approx}$.  If $t \approx t'$,
 then $[t]_\approx = [t']_\approx$, but we can't have both $[t]_\approx
 \in \Assign{R}{M/_\approx}$ and $[t]_\approx \notin
 \Assign{R}{M/_\approx}$.  However, \olref{prop:approx-equiv}
@@ -155,8 +155,8 @@ The only case that needs additional attention is when $!A \ident
 \eq[t][t']$.
 \begin{align*}
 \Sat{M/_\approx}{\eq[t][t']} & \text{ iff } [t]_\approx = [t']_\approx
-\text{ (by definition of $\Struct{M/_\approx}$)}\\ 
-& \text{ iff } t \approx t' \text{ (by definition of $[t]_\approx$)}\\ 
+\text{ (by definition of $\Struct{M/_\approx}$)}\\
+& \text{ iff } t \approx t' \text{ (by definition of $[t]_\approx$)}\\
 & \text{ iff } \eq[t][t'] \in \Gamma^* \text{ (by definition of $\approx$).}
 \end{align*}
 \end{proof}
@@ -166,7 +166,7 @@ Note that while $\Struct{M(\Gamma^*)}$ is always !!{enumerable} and
 infinite, $\Struct{M/_\approx}$ may be finite, since it may turn out
 that there are only finitely many classes $[t]_\approx$.  This is to
 be expected, since $\Gamma$ may contain !!{sentence}s which require
-any !!{structure} in which they are true to be finite. For instance,
+any !!{structure} in which they are true to be finite.  For instance,
 $\lforall[x][\lforall[y][x = y]]$ is a consistent !!{sentence}, but is
 satisfied only in !!{structure}s with a !!{domain} that contains
 exactly one !!{element}.

--- a/first-order-logic/completeness/introduction.tex
+++ b/first-order-logic/completeness/introduction.tex
@@ -11,7 +11,7 @@
 
 The completeness theorem is one of the most fundamental results about
 logic.  It comes in two formulations, the equivalence of which we'll
-prove. In its first formulation it says something fundamental about
+prove.  In its first formulation it says something fundamental about
 the relationship between semantic consequence and our proof system: if
 a !!{sentence}~$!A$ follows from some !!{sentence}s $\Gamma$, then
 there is also a !!{derivation} that establishes $\Gamma \Proves !A$.
@@ -21,7 +21,7 @@ it can be stated as a model existence result: every consistent set of
 !!{sentence}s is satisfiable.
 
 These aren't the only reasons the completeness theorem---or rather,
-its proof---is important. It has a number of important consequences,
+its proof---is important.  It has a number of important consequences,
 some of which we'll discuss separately.  For instance, since any
 !!{derivation} that shows $\Gamma \Proves !A$ is finite and so can
 only use finitely many of the !!{sentence}s in~$\Gamma$, it follows by
@@ -31,6 +31,6 @@ called \emph{compactness}.  Equivalently, if every finite subset of
 $\Gamma$ is consistent, then $\Gamma$ itself must be consistent.  It
 also follows from \emph{the proof of} the completeness theorem that
 any satisfiable set of !!{sentence}s has a finite or !!{denumerable}s
-model. This result is called the L\"owenheim-Skolem theorem.
+model.  This result is called the L\"owenheim-Skolem theorem.
 
 \end{document}

--- a/first-order-logic/completeness/lindenbaums-lemma.tex
+++ b/first-order-logic/completeness/lindenbaums-lemma.tex
@@ -19,14 +19,14 @@ consistent saturated set~$\Gamma^*$.
 Let $\Gamma$ be consistent, and let $\Gamma'$ be as in the proof of
 \olref[hen]{thm:henkin}: we proved there that $\Gamma \cup \Gamma'$
 is a consistent saturated set in the richer language $\Lang L'$ (with
-the !!{denumerable} set of new constants). Let $!A_0$, $!A_1$, \dots{}
-be an enumeration of all the !!{formula}s of~$\Lang L'$. Define
+the !!{denumerable} set of new constants).  Let $!A_0$, $!A_1$, \dots{}
+be an enumeration of all the !!{formula}s of~$\Lang L'$.  Define
 $\Gamma_0 = \Gamma \cup \Gamma'$, and
 \[
 \Gamma_{n+1} =
 \begin{cases}
 \Gamma_n \cup \{ !A_n \} & \textrm{if $\Gamma_n \cup \{!A_n\}$ is
-  consistent;} \\ 
+  consistent;} \\
 \Gamma_n \cup \{ \lnot !A_n \} & \textrm{otherwise.}
 \end{cases}
 \]
@@ -34,13 +34,13 @@ $\Gamma_0 = \Gamma \cup \Gamma'$, and
 Let $\Gamma^* = \bigcup_{n \geq 0} \Gamma_n$. Since $\Gamma' \subseteq
 \Gamma^*$, for each !!{formula}~$!A$, $\Gamma^*$ contains a
 !!{formula} of the form
-\iftag{prvEx} 
+\iftag{prvEx}
 {$\lexists[x][!A] \lif !A(c)$}
 {$\lnot\lforall[x][!A] \lif \lnot !A(c)$}
 and thus is saturated.
 
 Each $\Gamma_n$ is consistent: $\Gamma_0$ is consistent by
-definition. If $\Gamma_{n+1} = \Gamma_n \cup \{!A\}$, this is because
+definition.  If $\Gamma_{n+1} = \Gamma_n \cup \{!A\}$, this is because
 the latter is consistent.  If it isn't, $\Gamma_{n+1} = \Gamma_n \cup
 \{!\lnot !A\}$, which must be consistent.  If it weren't, i.e., both
 $\Gamma_n \cup \{!A\}$ and $\Gamma_n \cup \{\lnot !A\}$ are

--- a/first-order-logic/completeness/maximally-consistent-sets.tex
+++ b/first-order-logic/completeness/maximally-consistent-sets.tex
@@ -39,7 +39,7 @@ Maximally consistent sets are important in the completeness proof
 since we can guarantee that every consistent set of !!{sentence}s~$\Gamma$
 is contained in a maximally consistent set~$\Gamma^*$, and a maximally
 consistent set contains, for each !!{sentence}~$!A$, either $!A$ or its
-negation $\lnot !A$.  This is true in particular for atomic !!{sentence}s,
+negation $\lnot !A$. This is true in particular for atomic !!{sentence}s,
 so from a maximally consistent set in a language suitably expanded by
 !!{constant}s, we can construct a !!{structure} where the
 interpretation of !!{predicate}s is defined according to which atomic
@@ -80,7 +80,7 @@ consistent.
 Suppose that $\Gamma \Proves !A$. Suppose to the contrary that $!A
 \notin \Gamma$: then since $\Gamma$ is maximally consistent, $\Gamma
 \cup \{!A\}$ is inconsistent, hence $\Gamma \cup \{!A\} \Proves
-\lfalse$.  By
+\lfalse$. By
 \olref[seq][prv]{prop:provability}\olref[seq][prv]{prop:provability-contr}
 $\Gamma$ is inconsistent. This contradicts the assumption that
 $\Gamma$ is consistent. Hence, it cannot be the case that $!A \notin
@@ -94,7 +94,7 @@ $\Gamma \cup \{!A\}$ and $\Gamma \cup \{\lnot !A\}$ are both
 inconsistent, so $\Gamma \cup \{!A\} \Proves \lfalse$ and $\Gamma \cup
 \{\lnot !A\} \Proves \lfalse$. By
 \olref[seq][prv]{prop:provability}\olref[seq][prv]{prop:provability-exhaustive},
-$\Gamma$ is inconsistent, a contradiction.  Hence there cannot be such
+$\Gamma$ is inconsistent, a contradiction. Hence there cannot be such
 a !!{sentence}~$!A$ and, for every $!A$, $!A \in \Gamma$ or $\lnot !A
 \in \Gamma$.
 
@@ -131,7 +131,7 @@ $\Gamma \cup \{(!A \lor !B)\}$ is inconsistent. Hence, $(!A \lor !B)
 For the reverse direction, suppose that $!A \in \Gamma$ or $!B \in
 \Gamma$. Then $\Gamma \Proves !A$ or $\Gamma \Proves !B$. By
 \olref[seq][prv]{prop:provability}\olref[seq][prv]{prop:provability-lor-right},
-$\Gamma \Proves !A \lor !B$.  By \olref{prop:mcs-prov-in}, $(!A \lor !B)
+$\Gamma \Proves !A \lor !B$. By \olref{prop:mcs-prov-in}, $(!A \lor !B)
 \in \Gamma$, as required.}}
 
 \tagitem{defIf}{}{%

--- a/first-order-logic/completeness/outline.tex
+++ b/first-order-logic/completeness/outline.tex
@@ -26,7 +26,7 @@ with the hypothesis that it is consistent to construct a model.  After
 all, we know what kind of model we are looking for: one that is as
 $\Gamma$ describes it!
 
-If $\Gamma$ contains only atomic sentences, it is actually very easy
+If $\Gamma$ contains only atomic sentences, it is easy
 to construct a model for it: for atomic sentences are all of the form
 $\Atom{P}{a_1,\dots,a_n}$ where the $a_i$ are !!{constant}s.  So all
 we have to do is come up with a !!{domain}~$\Domain{M}$ and an
@@ -46,10 +46,9 @@ if $!B \notin \Gamma$, then according to our construction of~$\Struct M$,
 $\Sat/{M}{!B}$, so $\Sat{M}{\lnot !B}$.  So far so good.
 
 Now what if $\Gamma$ contains complex, non-atomic formulas? Say, it
-contains $!A \land !B$. Then obviously
-we should proceed as if both $!A$ and $!B$ were in $\Gamma$.  And if
-$!A \lor !B \in \Gamma$, then we will have to make at least one of
-them true, i.e., proceed as if one of them was in`$\Gamma$.
+contains $!A \land !B$. Then we should proceed as if both $!A$ and $!B$ were
+in $\Gamma$.  And if $!A \lor !B \in \Gamma$, then we will have to make at
+least one of them true, i.e., proceed as if one of them was in`$\Gamma$.
 
 This suggests the following idea: we add additional sentences to
 $\Gamma$ so as to (a) keep the resulting set consistent and (b) make
@@ -57,15 +56,15 @@ sure that for every possible atomic sentence $!A$, either $!A$ is in
 the resulting set, or $\lnot !A$, and (c) such that, whenever $!A \land
 !B$ is in the set, so are both $!A$ and $!B$, if $!A \lor !B$ is in
 the set, at least one of $!A$ or $!B$ is also, etc.  We keep doing this
-(potentially forever). Call the set of all sentences so
-added~$\Gamma^*$. Then our construction above would provide us with a
+(potentially forever).  Call the set of all sentences so
+added~$\Gamma^*$.  Then our construction above would provide us with a
 structure for which we could prove, by induction, that all sentences
 in~$\Gamma^*$ are true in~$\Struct M$, and hence also all sentence
 in~$\Gamma$ since $\Gamma \subseteq \Gamma^*$.
 
 There is one wrinkle in this plan: if $\lexists[x][!A(x)] \in \Gamma$
 we would hope to be able to pick some !!{constant}~$c$ and add $!A(c)$
-in this process.  But how do we know we can always do that? Perhaps we
+in this process.  But how do we know we can always do that?  Perhaps we
 only have a few !!{constant}s in our language, and for each one of
 them we have $\lnot !B(c) \in \Gamma$.  We can't also add $!B(c)$,
 since this would make the set inconsistent, and we wouldn't know
@@ -80,12 +79,12 @@ quantifiers in the right way.  (Of course, we have to verify that this
 cannot introduce an inconsistency.)
 
 Our original construction works well if we only have !!{constant}s in
-the atomic sentences. But the language might also contain
+the atomic sentences.  But the language might also contain
 !!{function}s.  In that case, it might be tricky to find the right
 functions on~$\Nat$ to assign to these !!{function}s to make
 everything work.  So here's another trick: instead of using $i$ to
 interpret $\Obj c_i$, just take the set of !!{constant}s itself as the
-domain. Then $\Struct M$ can assign every !!{constant} to itself:
+domain.  Then $\Struct M$ can assign every !!{constant} to itself:
 $\Assign{\Obj c_i}{M} = \Obj c_i$.  But why not go all the way: let
 $\Domain{M}$ be all \emph{terms} of the language!{} If we do this,
 there is an obvious assignment of functions (that take terms as
@@ -96,14 +95,14 @@ as value.
 
 The last piece of the puzzle is what to do with~$\eq$.  The
 !!{predicate}~$\eq$ has a fixed interpretation: $\Sat{M}{\eq[t][t']}$
-iff $\Value{t}{M} = \Value{t'}{M}$. Now if we set things up so that the
-!!{value} of a term~$t$ is $t$ itself, then this !!{structure} 
+iff $\Value{t}{M} = \Value{t'}{M}$.  Now if we set things up so that the
+!!{value} of a term~$t$ is $t$ itself, then this !!{structure}
 will make \emph{no} sentence of the form $\eq[t][t']$ true
 unless $t$ and $t'$ are one and the same term.  And of
 course this is a problem, since basically every interesting theory in
 a language with !!{function}s will have as theorems sentences
 $\eq[t][t']$ where $t$ and $t'$ are not the same term (e.g., in
-theories of arithmetic: $\eq[(\Obj 0+ \Obj 0)][\Obj 0]$). To solve
+theories of arithmetic: $\eq[(\Obj 0+ \Obj 0)][\Obj 0]$).  To solve
 this problem, we change the domain of~$\Struct M$: instead of using terms as
 the objects in~$\Domain{M}$, we use sets of terms, and each set is so
 that it contains all those terms which the sentences in~$\Gamma$
@@ -111,7 +110,7 @@ require to be equal.  So, e.g., if $\Gamma$ is a theory of arithmetic,
 one of these sets will contain: $\Obj 0$, $(\Obj 0 + \Obj 0)$, $(\Obj
 0 \times \Obj 0)$, etc.  This will be the set we assign to $\Obj 0$,
 and it will turn out that this set is also the value of all the terms
-in it, e.g., also of $(\Obj 0 + \Obj 0)$. Therefore, the sentence
+in it, e.g., also of $(\Obj 0 + \Obj 0)$.  Therefore, the sentence
 $\eq[(\Obj 0+ \Obj 0)][\Obj 0]$ will be true in this revised
 !!{structure}.
 

--- a/first-order-logic/model-theory/dlo.tex
+++ b/first-order-logic/model-theory/dlo.tex
@@ -17,7 +17,7 @@
   \item $\lforall[x] \ x < x$;
   \item $\lforall[x][\lforall[y][\lforall[z][(x < y \lif (y < z \lif x
     <z ))]]]$;
-  \item $\lforall[x][\lforall[y][(x< y \lor \eq[x][y] \lor y < x)]]$; 
+  \item $\lforall[x][\lforall[y][(x< y \lor \eq[x][y] \lor y < x)]]$;
   \item $\lforall[x][\lexists[y][x < y]]$;
   \item $\lforall[x][\lexists[y][y < x]]$;
   \item $\lforall[x][\lforall[y][(x < y \lif \lexists[z][(x < z \land

--- a/first-order-logic/model-theory/isomorphism.tex
+++ b/first-order-logic/model-theory/isomorphism.tex
@@ -27,11 +27,11 @@
   function $h\colon \Domain{M} \to \Domain{M'}$ such that:
   \begin{enumerate}
   \item $h$ is one-one: if $h(x) =
-    h(y)$ then $x = y$; 
+    h(y)$ then $x = y$;
   \item $h$ is onto $\Domain{M'}$: for every $y \in
     \Domain{M'}$ there is $x \in \Domain{M}$ such that $h(x) = y$;
   \item for every constant $c$: $h(\Assign{c}{M}) =
-    \Assign{c}{M'}$; 
+    \Assign{c}{M'}$;
   \item for every $n$-place !!{predicate} $P$: $\langle
     a_1,\dots,a_n\rangle \in \Assign{P}{M}$ if and only if  $\langle
     h(a_1),\dots,h(a_n)\rangle \in \Assign{P}{M'}$;
@@ -52,14 +52,14 @@
   $\Struct M'$; for any assignment $s$, $h \circ s$ is the
   composition of $h$ and $s$, i.e., the assignment in
   $\Struct M'$ such that  $(h \circ s)(x) = h(s(x))$.
-  We proceed by induction on $t$ $!A$ and prove the stronger claims: 
+  We proceed by induction on $t$ $!A$ and prove the stronger claims:
   \begin{align*}
   &  h(\Value{t}{M}[s]) = \Value{t}{M'}[h\circ s];\\
   &  \Sat{M}{!A}[s] \text{ if and only if }
     \Sat{M'}{!A}[h \circ s].
   \end{align*}
 Make sure to take note at each step of how each of the five properties
-characterizing isomorphisms is used.    
+characterizing isomorphisms is used.
 \end{proof}
 
 

--- a/first-order-logic/model-theory/nonstandard-arithmetic.tex
+++ b/first-order-logic/model-theory/nonstandard-arithmetic.tex
@@ -13,7 +13,7 @@
   Let $\Lang{L}_N$ be the language of arithmetic, comprising a
   !!{constant} $\mathbf{0}$, a 2-place !!{predicate} $<$, a 1-place
   !!{function} $s$, and 2-place !!{function}s $+$ and
-  $\times$. 
+  $\times$.
   \begin{enumerate}
   \item The \emph{standard model} of arithmetic is the !!{structure}
     $\Struct{N}$ for $\Lang{L}_N$ having $\Nat = \{ 0, 1, 2,
@@ -41,7 +41,7 @@ successor function to $\mathbf{0}$, as $\mathbf{n}$.
 
 \begin{proof}
   Expand $\Lang{L}_N$ by introducing a new constant, $c$, and
-  consider the theory 
+  consider the theory
   \[
   \Theory{N}) \cup \{\mathbf{n} < c
   : n \in \Nat \}.
@@ -56,7 +56,7 @@ successor function to $\mathbf{0}$, as $\mathbf{n}$.
   $x$ by application of $*$.
 
   Now, if $h$ were an isomorphism of $\Struct{N}$ and $\Struct{M}$,
-  there would be $n \in \Nat$ such that $h(n) = c^\Struct{M}$.  So let
+  there would be $n \in \Nat$ such that $h(n) = c^\Struct{M}$. So let
   $s$ be any assignment in $\Struct{N}$ such that $s(x) = n$ (we use
   $s$ both for the successor symbol in $\Lang{L}_N$ and the
   assignment: no confusion should arise). Then
@@ -80,7 +80,7 @@ of !!{enumerable} non-standard models of $\Theory{N})$.
   $\Struct{M}$.
 \item By a similar reasoning we obtain that $\prec$ is a \emph{linear
     ordering} of $M$, i.e., a total, irreflexive, transitive relation
-  on $M$. 
+  on $M$.
 \item The element $\mathbf{z}$ is the $\prec$-least element of $M$.
 \item Any member of $M$ is $\prec$-less than its $*$-successor and
   $x^*$ is the $\prec$-least member of $M$ greater than $x$.
@@ -89,7 +89,7 @@ of !!{enumerable} non-standard models of $\Theory{N})$.
   \mathbf{z}^{**}, \dots$, which we call the \emph{standard part} of
   $M$. Any other member of $M$ is \emph{non-standard}. There must be
   non-standard members of $M$, or else the function $h$ from
-  the proof of \olref{thm:non-std} is an isomorphism.  We use
+  the proof of \olref{thm:non-std} is an isomorphism. We use
   $n, m, \dots$ as !!{variable}s ranging on this standard part of
   $\Struct{M}$.
 \item Every non-standard element is greater than any standard one;
@@ -99,7 +99,7 @@ of !!{enumerable} non-standard models of $\Theory{N})$.
   \dots \lor \eq[z][\mathbf{n}]) \lif \mathbf{n} < z)]},
   \]
   so if $z \in M$ is different from all the standard elements, it must
-  be \emph{greater} than all of them. 
+  be \emph{greater} than all of them.
 \item Any member of $M$ other than $\mathbf{z}$ is the $*$-successor
   of some unique element of $M$, denoted by $^*x$. If $x = y^*$ then
   both $x$ and $y$ are standard if one of them is (and both
@@ -110,7 +110,7 @@ of !!{enumerable} non-standard models of $\Theory{N})$.
   \approx y$ if and only if $x$ and $y$ are a finite distance
   apart. If $n$ and $m$ are standard then $n \approx m$. Define the
   \emph{block} of $x$ to be the equivalence class $[x] = \{y: x
-  \approx y \}$. 
+  \approx y \}$.
 \item Suppose that $x \prec y$ where $x \not\approx y$; then either
   $x^* \prec y$ or $x^* = y$; the latter is impossible because it
   implies $x \approx y$, so $x \prec y$. Similarly, if $x \prec y$ and
@@ -127,7 +127,7 @@ of !!{enumerable} non-standard models of $\Theory{N})$.
 \item The $\prec$ ordering can be lifted up the blocks: if $x \prec y$
   then the block of $x$ is less than the block of $y$. A block is
   \emph{non-standard} if it contains a non-standard element. The
-  standard block is the least block. 
+  standard block is the least block.
 \item There is no least non-standard block: if $y$ is non-standard
   then there is a $x \prec y$ where $x$ is also non-standard and $x
   \not\approx y$. Proof: in the standard model $\Struct{N}$, every
@@ -141,7 +141,7 @@ of !!{enumerable} non-standard models of $\Theory{N})$.
   $\Struct{N}$ and therefore in $\Struct{M}$ as well), and $x$
   would be standard after all. (Similarly if  $x \oplus x \oplus
   \mathbf{z}^*= y$.)
-\item By a similar argument, there is no greatest block. 
+\item By a similar argument, there is no greatest block.
 \item The ordering of the blocks is dense: if $[x]$ is less than $[y]$
   (where $x \not\approx y$), then there is a block $[z]$ distinct from
   both that is between them. Suppose $x \prec y$. As before, $x
@@ -170,7 +170,7 @@ therefore by \olref[dlo]{thm:cantorQ} are isomorphic; an isomorphism
 of the blocks can be extended to an isomorphism \emph{within} the
 blocks by matching up arbitrary elements in each, and then taking the
 image of the successor of $x$ in $\Struct{M}_1$ to be the successor
-of the image of $x$ in $\Struct{M}_2$. 
+of the image of $x$ in $\Struct{M}_2$.
 
 
 \end{document}

--- a/first-order-logic/model-theory/partial-iso.tex
+++ b/first-order-logic/model-theory/partial-iso.tex
@@ -51,7 +51,7 @@ between any two !!{structure}s.
 \begin{thm}\ollabel{thm:p-isom1}
   If $\Struct{M} \iso[p] \Struct{N}$ and $\Struct{M}$ and
   $\Struct{N}$ are !!{enumerable}, then $\Struct{M} \iso
-  \Struct{N}$. 
+  \Struct{N}$.
 \end{thm}
 
 \begin{proof}
@@ -66,14 +66,14 @@ between any two !!{structure}s.
     and $a_r$ is in the domain of $p_{n+1}$;
   \item if $n+1$ is even, say $n+1 =2r$, then using the Back property
     find a $p_{n+1} \in I$ such that $p_n \subseteq p_{n+1}$
-    and $b_r$ is in the range of $p_{n+1}$. 
+    and $b_r$ is in the range of $p_{n+1}$.
   \end{enumerate}
 If we now put:
 \[
 p = \bigcup_{n\ge 0} p_n,
 \]
 We have that $p$ is a an isomorphism of $\Struct{M}$ onto
-$\Struct{N}$.  
+$\Struct{N}$.
 \end{proof}
 
 \begin{thm}\ollabel{thm:p-isom2}
@@ -112,7 +112,7 @@ how many times the relevant partial isomorphisms can be extended.
   sentences of quantifier rank less than or equal to~$n$.
 \end{defn}
 
-\begin{prop}\ollabel{prop:qr-finite} 
+\begin{prop}\ollabel{prop:qr-finite}
   Let $\Lang{L}$ be a finite purely relational language, i.e., a
   language containing finitely many !!{predicate}s and !!{constant}s,
   and no !!{function}s. Then for each $n \in \Nat$ there are
@@ -158,7 +158,7 @@ how many times the relevant partial isomorphisms can be extended.
 \end{defn}
 
 \begin{thm}\ollabel{thm:b-n-f}
-  Let $\Lang{L}$ be a purely relational language.  Then $I_n
+  Let $\Lang{L}$ be a purely relational language. Then $I_n
   (\mathbf{a},\mathbf{b})$ implies that for every $!A$ such that
   $\QuantRank{!A} \le n$, we have $\Sat{M}{!A}[\mathbf{a}]$ if and
   only if $\Sat{N}{!A}[\mathbf{b}]$ (where again $\mathbf{a}$

--- a/first-order-logic/model-theory/theory-of-m.tex
+++ b/first-order-logic/model-theory/theory-of-m.tex
@@ -9,7 +9,7 @@
 \olfileid{fol}{mod}{thm}
 \section{The Theory of a \printtoken{s}{structure}}
 
-\begin{defn} 
+\begin{defn}
   Given a !!{structure}~$\Struct M$, the \emph{theory} of
   $\Struct{A}$ is the set $\Theory{M}$ of sentences
   that are true in $\Struct{M}$, i.e., $\Theory{M} =
@@ -24,7 +24,7 @@ closed or not.
   For any $\Struct{M}$,  $\Theory{M}$ is maximally
   consistent. Hence, if $\Struct{N} \models !A$ for every $!A
   \in \Theory{M}$, then $\Struct{M} \elemequiv
-  \Struct{N}$. 
+  \Struct{N}$.
 \end{prop}
 
 \begin{proof}
@@ -40,7 +40,7 @@ closed or not.
   whose domain is the set $\Real$ of the real numbers, in the language
   comprising only a 2-place !!{predicate} interpreted as the $<$ relation
   over the reals. Clearly $\Struct{R}$ is uncountable; however, since
-  $\Theory{R}$ is obviously consistent, by the L\"owenheim-Skolem
+  $\Theory{R}$ is consistent, by the L\"owenheim-Skolem
   theorem it has a countable model, say $\Struct{S}$, and by
   Proposition \olref{prop:equiv}, $\Struct{R} \equiv
   \Struct{S}$. Moreover, since $\Struct{R}$ and $\Struct{S}$ are not

--- a/first-order-logic/models-theories/expressing-props-of-structures.tex
+++ b/first-order-logic/models-theories/expressing-props-of-structures.tex
@@ -6,12 +6,12 @@
 
 \begin{document}
 
-\olfileid{fol}{mat}{exs} 
+\olfileid{fol}{mat}{exs}
 
 \olsection{Expressing Properties of \printtoken{P}{structure}}
 
 \begin{explain}
-It is very often useful and important to express conditions on
+It is often useful and important to express conditions on
 functions and relations, or more generally, that the functions and
 relations in a structure satisfy these conditions.  For instance, we
 would like to have ways of distinguishing those !!{structure}s for a
@@ -22,7 +22,7 @@ interpretation of the !!{predicate}~$\le$ must be an ordering, or that
 we are only interested in interpretations of~$\Lang L$ in which the
 domain consists of sets and $\Obj \in$ is interpreted by the ``is
 !!a{element} of'' relation.  But can we do this with !!{sentence}s of
-the language? In other words, which conditions on
+the language?  In other words, which conditions on
 !!a{structure}~$\Struct M$ can we express by !!a{sentence} (or perhaps
 a set of !!{sentence}s) in the language of~$\Struct M$?  There are
 some conditions that we will not be able to express.  For instance,
@@ -31,7 +31,7 @@ there is no sentence of~$\Lang L_A$ which is only true in a
 ``the domain contains only natural numbers.''  But there are
 ``structural properties'' of !!{structure}s that we perhaps can
 express.  Which properties of !!{structure}s can we express by
-!!{sentence}s? Or, to put it another way, which collections of
+!!{sentence}s?  Or, to put it another way, which collections of
 !!{structure}s can we describe as those making !!a{sentence} (or set
 of !!{sentence}s) true?
 \end{explain}
@@ -44,7 +44,7 @@ $\Sat{M}{!A}$ for all $!A \in \Gamma$.
 
 \begin{ex}
 The sentence $\lforall[x][x \le x]$ is true in~$\Struct M$ iff
-$\Assign{\le}{M}$ is a reflexive relation. The sentence
+$\Assign{\le}{M}$ is a reflexive relation.  The sentence
 $\lforall[x][\lforall[y][((x \le y \land y \le x) \lif x = y)]]$ is
 true in~$\Struct M$ iff $\Assign{\le}{M}$ is anti-symmetric.  The
 sentence $\lforall[x][\lforall[y][\lforall[z][((x \le y \land y \le z)

--- a/first-order-logic/models-theories/expressing-relations.tex
+++ b/first-order-logic/models-theories/expressing-relations.tex
@@ -6,7 +6,7 @@
 
 \begin{document}
 
-\olfileid{fol}{mat}{exr} 
+\olfileid{fol}{mat}{exr}
 
 \olsection{Expressing Relations in \article{structure}
   \printtoken{S}{structure}}
@@ -68,7 +68,7 @@ of arithmetic; it can be defined.
 
 This idea is not just interesting in specific !!{structure}s, but
 generally whenever we use a language to describe an intended model or
-models, i.e., when we consider theories. These theories often only
+models, i.e., when we consider theories.  These theories often only
 contain a few !!{predicate}s as basic symbols, but in the domain they
 are used to describe often many other relations play an important
 role.  If these other relations can be systematically expressed by the
@@ -87,7 +87,7 @@ Find !!{formula}s in $\Lang L_A$ which define the following relations:
 
 \begin{prob}
 Suppose the formula $!A(\Obj x_1, \Obj x_2)$ expresses the relation $R
-\subseteq \Domain M^2$ in a !!{structure}~$\Struct M$. Find formulas
+\subseteq \Domain M^2$ in a !!{structure}~$\Struct M$.  Find formulas
 that express the following relations:
 \begin{enumerate}
 \item the inverse $R^{-1}$ of $R$;

--- a/first-order-logic/models-theories/introduction.tex
+++ b/first-order-logic/models-theories/introduction.tex
@@ -13,7 +13,7 @@
 The development of the axiomatic method is a significant achievement
 in the history of science, and is of special importnace in the history
 of mathematics.  An axiomatic development of a field involves the
-clarification of many questions: What is the field about? What are the
+clarification of many questions: What is the field about?  What are the
 most fundamental concepts?  How are they related?  Can all the
 concepts of the field be defined in terms of these fundamental
 concepts?  What laws do, and must, these concepts obey?
@@ -41,13 +41,13 @@ have a first-order language which contains non-logical symbols for the
 primitives of the axiomatically developed science we wish to study,
 together with a set of !!{sentence}s that express the fundamental laws
 of the science, we can think of the theory as represented by all the
-!!{sentence}s in this language that are entailed by the axioms. This
-ranges from very simple examples with only a single primitive and very
-simple axioms like the theory of partial orders to very complex
-theories like Newtonian mechanics.
+!!{sentence}s in this language that are entailed by the axioms.  This
+ranges from simple examples with only a single primitive and
+simple axioms, such as the theory of partial orders, to complex
+theories such as Newtonian mechanics.
 
-The important logical facts that make this formal approach to the 
-axiomatic method so important are the following. Suppose $\Gamma$ is
+The important logical facts that make this formal approach to the
+axiomatic method so important are the following.  Suppose $\Gamma$ is
 an axiom system for a theory, i.e., a set of sentences.
 \begin{enumerate}
 \item We can state precisely when an axiom system captures an intended
@@ -57,7 +57,7 @@ an axiom system for a theory, i.e., a set of sentences.
   those~$\Struct M$ such that $\Sat{M}{\Gamma}$.
 \item We may fail in this respect because there are $\Struct M$ such
   that $\Sat{M}{\Gamma}$, but $\Struct M$ is not one of the
-  !!{structure}s we intend. This may lead us to add axioms which are
+  !!{structure}s we intend.  This may lead us to add axioms which are
   not true in~$\Struct M$.
 \item If we are successful at least in the respect that $\Gamma$ is
   true in all the intended !!{structure}s, then a sentence~$!A$ is true in
@@ -71,7 +71,7 @@ an axiom system for a theory, i.e., a set of sentences.
   One thing that we would like to verify right away is that the axioms
   do not contradict each other: if they do, there can be no concepts
   that obey these laws, and we have tried to set up an incoherent
-  theory. We can verify that this doesn't happen by finding a model
+  theory.  We can verify that this doesn't happen by finding a model
   of~$\Gamma$.  And if there are models of our theory, we can use
   logical methods to investigate them, and we can also use logical
   methods to construct models.
@@ -81,11 +81,11 @@ an axiom system for a theory, i.e., a set of sentences.
   an axiom $!A$ in $\Gamma$ is redundant by proving $\Gamma \setminus
   \{!A\} \Entails !A$.  We can also prove that an axiom is not
   redundant by showing that $(\Gamma \setminus \{!A\}) \cup \{\lnot
-  !A\}$ is satisfiable. For instance, this is how it was shown that the
+  !A\}$ is satisfiable.  For instance, this is how it was shown that the
   parallel postulate is independent of the other axioms of geometry.
 \item Another important question is that of definability of concepts
   in a theory: The choice of the language determines what the models
-  of a theory consists of. But not every aspect of a theory must be
+  of a theory consists of.  But not every aspect of a theory must be
   represented separately in its models.  For instance, every ordering
   $\le$ determines a corresponding strict ordering~$<$---given one, we
   can define the other.  So it is not necessary that a model of a

--- a/first-order-logic/models-theories/set-theory.tex
+++ b/first-order-logic/models-theories/set-theory.tex
@@ -6,7 +6,7 @@
 
 \begin{document}
 
-\olfileid{fol}{mat}{set} 
+\olfileid{fol}{mat}{set}
 
 \olsection{The Theory of Sets}
 
@@ -14,7 +14,7 @@ Almost all of mathematics can be developed in the theory of sets.
 Developing mathematics in this theory involves a number of things.
 First, it requires a set of axioms for the relation~$\in$.  A number
 of different axiom systems have been developed, sometimes with
-conflicting properties of~$\in$. The axiom system known as
+conflicting properties of~$\in$.  The axiom system known as
 $\Log{ZFC}$, Zermelo-Fraenkel set theory with the axiom of choice
 stands out: it is by far the most widely used and studied, because it
 turns out that its axioms suffice to prove almost all the things
@@ -34,7 +34,7 @@ can \emph{define} ``is a subset of'' in terms of ``is an element of.''
 To do this, we have to find a !!{formula}~$!A(x, y)$ in
 the language of set theory which is satisfied by a pair of
 sets~$\tuple{X, Y}$ iff $X \subseteq Y$.  But $X$ is a subset of $Y$
-just in case all !!{element}s of~$X$ are also !!{element}s of~$Y$. So
+just in case all !!{element}s of~$X$ are also !!{element}s of~$Y$.  So
 we can define $\subseteq$ by the formula
 \[
 \lforall[z][(z \in x \lif z \in y)]
@@ -120,7 +120,7 @@ function from $X$ to $Y$'' can be written as:
 \begin{align*}
  \lforall[u][(u \in f \lif {}] & \lexists[x][\lexists[y][(x \in X \land y \in
       Y \land \tuple{x, y} = u)]]) \land {}\\
- \lforall[x][(x \in X \lif {}] & 
+ \lforall[x][(x \in X \lif {}] &
       (\lexists[y][(y \in Y \land \mathrm{maps}(f, x, y))] \land {}\\
 & (\lforall[y][\lforall[y'][((\mathrm{maps}(f, x, y) \land
     \mathrm{maps}(f, x, y')) \lif y = y')]]))

--- a/first-order-logic/models-theories/size-of-structures.tex
+++ b/first-order-logic/models-theories/size-of-structures.tex
@@ -6,7 +6,7 @@
 
 \begin{document}
 
-\olfileid{fol}{mat}{siz} 
+\olfileid{fol}{mat}{siz}
 
 \olsection{Expressing the Size of \printtoken{P}{structure}}
 
@@ -22,7 +22,7 @@ number~$n$ of !!{element}s.
 The !!{sentence}
 \begin{align*}
 !A_{\ge n} & \ident \lexists[x_1][\lexists[x_2][\dots\lexists[x_n][{}]]] &
-  (\eq/[x_1][x_2] \land {} 
+  (\eq/[x_1][x_2] \land {}
   \eq/[x_1][x_3] \land \eq/[x_1][x_4] \land \dots \land \eq/[x_1][x_n] \land {}\\
 & & \eq/[x_2][x_3] \land \eq/[x_2][x_4] \land \dots \land {} \eq/[x_2][x_n] \land {} \\
 & & \vdots\\
@@ -38,7 +38,7 @@ $\Domain M$ contains at most~$n$ !!{element}s.
 The !!{sentence}
 \begin{align*}
 !A_{= n} & \ident \lexists[x_1][\lexists[x_2][\dots\lexists[x_n][{}]]] &
-  (\eq/[x_1][x_2] \land {} 
+  (\eq/[x_1][x_2] \land {}
   \eq/[x_1][x_3] \land \eq/[x_1][x_4] \land \dots \land \eq/[x_1][x_n] \land {}\\
 & & \eq/[x_2][x_3] \land \eq/[x_2][x_4] \land \dots \land {} \eq/[x_2][x_n] \land {} \\
 & & \vdots\\

--- a/first-order-logic/models-theories/theories.tex
+++ b/first-order-logic/models-theories/theories.tex
@@ -6,7 +6,7 @@
 
 \begin{document}
 
-\olfileid{fol}{mat}{the} 
+\olfileid{fol}{mat}{the}
 
 \olsection{Examples of First-Order Theories}
 
@@ -30,7 +30,7 @@ $\Domain M = X$ and $\Assign{<}{M} = R$ is a model of this theory.
 The theory of groups in the language $\Obj 1$ (!!{constant}), $\cdot$
 (two-place !!{function}) is axiomatized by
 \begin{align*}
-& \lforall[x][(x \cdot \Obj 1) = x]\\ 
+& \lforall[x][(x \cdot \Obj 1) = x]\\
 & \lforall[x][\lforall[y][\lforall[z][\eq[(x \cdot (y \cdot z))][((x
           \cdot y) \cdot z)]]]]\\
 & \lforall[x][\lexists[y][(x \cdot y) = \Obj 1]]
@@ -56,28 +56,28 @@ axiom system is infinite.  The latter form is called the
 \emph{induction schema}. (Actually, the induction schema is a bit more
 complicated than we let on here.)
 
-The second axiom is an \emph{explicit definition} of~$<$.  
+The second axiom is an \emph{explicit definition} of~$<$.
 \end{ex}
 
 \begin{ex}
 The theory of pure sets plays an important role in the foundations
-(and in the philosophy) of mathematics. A set is pure if all its
+(and in the philosophy) of mathematics.  A set is pure if all its
 !!{element}s are also pure sets.  The empty set counts therefore as
 pure, but a set that has something as !!a{element} that is not a set
-would not be pure. So the pure sets are those that are formed just
+would not be pure.  So the pure sets are those that are formed just
 from the empty set and no ``urelements,'' i.e., objects that are not
 themselves sets.
 
 The following might be considered as an axiom system for a theory of
 pure sets:
 \begin{align*}
-& \lexists[x][\lnot \lexists[y][y \in x]]\\ 
+& \lexists[x][\lnot \lexists[y][y \in x]]\\
 & \lforall[x][\lforall[y][(\lforall[z](z \in x \liff z \in y) \lif x =
-      y)]]\\ 
+      y)]]\\
 & \lforall[x][\lforall[y][\lexists[z][\lforall[u][(u \in z \liff (u =
-          x \lor u = y))]]]]\\ 
+          x \lor u = y))]]]]\\
 & \lforall[x][\lexists[y][\lforall[z][(z \in y \liff \lexists[u][(z \in
-        u \lor u \in x)])]]]\\ 
+        u \lor u \in x)])]]]\\
 \intertext{plus all sentences of the form} &
 \lexists[x][\lforall[y][(y \in x \liff !A(y))]]
 \end{align*}
@@ -89,7 +89,7 @@ fourth that for any sets $X$ and $Y$, the set $X \cup Y$ exists.
 The !!{sentence}s mentioned last are collectively called the
 \emph{naive comprehension scheme}.  It essentially says that for every
 $!A(x)$, the set $\Setabs{x}{!A(x)}$ exists---so at first glance a
-true, useful, and perhaps even necessary axiom. It is called ``naive''
+true, useful, and perhaps even necessary axiom.  It is called ``naive''
 because, as it turns out, it makes this theory unsatisfiable: if you
 take $!A(y)$ to be $\lnot y \in y$, you get the !!{sentence}
 \[
@@ -100,7 +100,7 @@ and this !!{sentence} is not satisfied in any !!{structure}.
 
 \begin{ex}
 In the area of \emph{mereology}, the relation of \emph{parthood} is a
-fundamental relation. Just like theories of sets, there are theories
+fundamental relation.  Just like theories of sets, there are theories
 of parthood that axiomatize various conceptions (sometimes
 conflicting) of this relation.
 
@@ -120,7 +120,7 @@ subset of,'' but does not resemble ``is an element of'' which is
 neither reflexive nor transitive.
 \begin{align*}
 & \lforall[x][\Atom{\Obj P}{x,x}], \\
-& \lforall[x][\lforall[y][((\Part{x}{y} \land \Part{y}{x}) 
+& \lforall[x][\lforall[y][((\Part{x}{y} \land \Part{y}{x})
       \lif x = y)]], \\
 & \lforall[x][\lforall[y][\lforall[z][((\Part{x}{y} \land
         \Part{y}{z}) \lif \Part{x}{z})]]],\\
@@ -133,7 +133,7 @@ These are only some of the basic principles of parthood considered by
 metaphysicians.  Further principles, however, quickly become hard to
 formulate or write down without first introducting some defined
 relations.  For instance, most metaphysicians interested in mereology
-also view the the following as a valid principle: whenever an
+also view the following as a valid principle: whenever an
 object~$x$ has a proper part~$y$, it also has a part~$z$ that has no
 parts in common with~$y$, and so that the fusion of $y$ and $z$ is
 $x$.

--- a/first-order-logic/sequent-calculus/identity.tex
+++ b/first-order-logic/sequent-calculus/identity.tex
@@ -93,12 +93,12 @@ and $!A(t_1)$ on the right, and the conclusion is $\Gamma \Sequent
 M$. Since, by induction hypothesis, the premise $\Gamma' \Sequent
 \Delta'$ is valid, either (a) for some $!E \in \Gamma'$,
 $\Sat/{M}{!E}$, (b) for some $!E \in \Delta' \setminus \{!A(s)\}$,
-$\Sat{M}{!E}$, or (c) $\Sat{M}{!A(t_1)}$.  In both cases cases (a) and
+$\Sat{M}{!E}$, or (c) $\Sat{M}{!A(t_1)}$. In both cases cases (a) and
 (b), since $\Gamma = \Gamma'$, and $\Delta' \setminus \{!A(s)\}
 \subseteq \Delta$, $\Struct M$ satisfies $\Gamma \Sequent \Delta$. So
-assume cases (a) and (b) do not apply, but case (c) does.  If (a) does
+assume cases (a) and (b) do not apply, but case (c) does. If (a) does
 not apply, $\Sat{M}{!E}$ for all $!E \in \Gamma'$, in particular,
-$\Sat{M}{\eq[t_1][t_2]}$.  Therefore, $\Value{t_1}{M} = \Value{t_2}{M}$.  Let
+$\Sat{M}{\eq[t_1][t_2]}$. Therefore, $\Value{t_1}{M} = \Value{t_2}{M}$. Let
 $s$ be any variable assignment, and $s'$ be the $x$-variant given by
 $s'(x) = \Value{t_1}{M} = \Value{t_2}{M}$. By
 \olref[fol][syn][ext]{prop:ext-formulas}, $\Sat{M}{!A(t_2)}[s]$ iff

--- a/first-order-logic/sequent-calculus/proof-theoretic-notions.tex
+++ b/first-order-logic/sequent-calculus/proof-theoretic-notions.tex
@@ -12,7 +12,7 @@
 \begin{explain}
 Just as we've defined a number of important semantic notions
 (validity, entailment, satisfiabilty), we now define corresponding
-\emph{proof-theoretic notions}. These are not defined by appeal to
+\emph{proof-theoretic notions}.  These are not defined by appeal to
 satisfaction of sentences in !!{structure}s, but by appeal to the
 !!{derivability} or !!{nonderivability} of certain sequents.  It was
 an important discovery, due to G\"odel, that these notions coincide.
@@ -21,7 +21,7 @@ That they do is the content of the \emph{completeness theorem}.
 
 \begin{defn}[Theorems]
 A sentence~$!A$ is a \emph{theorem} if there is a !!{derivation}
-in~$\Log{LK}$ of the sequent $\quad \Sequent !A$. We write
+in~$\Log{LK}$ of the sequent $\quad \Sequent !A$.  We write
 $\Proves[\Log{LK}] !A$ if $!A$ is a theorem and $\Proves/[\Log{LK}]
 !A$ if it is not.
 \end{defn}

--- a/first-order-logic/sequent-calculus/provability.tex
+++ b/first-order-logic/sequent-calculus/provability.tex
@@ -75,16 +75,16 @@ $\Delta \Proves !A$.
 \AxiomC{}
 \RightLabel{$\Pi_0$}
 \Deduce$ \Gamma_0 \fCenter !A $
-\doubleLine 
+\doubleLine
 \UnaryInf$ \Gamma_0,\Gamma_1 \fCenter !A $
 
 \AxiomC{}
 \RightLabel{$\Pi_1$}
 \Deduce$ \Gamma_1, !A \fCenter \lfalse$
-\doubleLine 
+\doubleLine
 \UnaryInf$ \Gamma_0, \Gamma_1, !A \fCenter \lfalse $
 
-\RightLabel{cut} 
+\RightLabel{cut}
 \BinaryInf$ \Gamma_0,\Gamma_1 \fCenter \lfalse $
 \end{prooftree}
 Since $\Gamma_0 \subseteq \Gamma$ and $\Gamma_1 \subseteq \Gamma$,
@@ -114,14 +114,14 @@ $\Gamma_0 \cup \Gamma_1 \subseteq \Gamma$, hence $\Gamma
 \AxiomC{}
 \RightLabel{$\Pi_0$}
 \Deduce$ \Gamma_0, !A \fCenter \lfalse $
-\RightLabel{$\lnot$ right} 
+\RightLabel{$\lnot$ right}
 \UnaryInf$ \Gamma_0 \fCenter \lnot !A$
 
 \AxiomC{}
 \RightLabel{$\Pi_1$}
 \Deduce$ \Gamma_1, \lnot !A \fCenter \lfalse $
 
-\RightLabel{cut} 
+\RightLabel{cut}
 \BinaryInf$ \Gamma_0, \Gamma_1 \fCenter \lfalse $
 \end{prooftree}
 Since $\Gamma_0 \subseteq \Gamma$ and $\Gamma_1 \subseteq \Gamma$,
@@ -137,16 +137,16 @@ $\Log{LK}$-!!{derivation}s $\Pi_0$ and $\Pi_1$ such that
 \AxiomC{}
 \RightLabel{$\Pi_0$}
 \Deduce$ \Gamma_0, !A \fCenter \lfalse $
-\doubleLine 
+\doubleLine
 \UnaryInf$ \Gamma_0, \Gamma_1, !A \fCenter \lfalse $
 
 \AxiomC{}
 \RightLabel{$\Pi_1$}
 \Deduce$ \Gamma_1, !B \fCenter \lfalse $
-\doubleLine 
+\doubleLine
 \UnaryInf$ \Gamma_0, \Gamma_1, !B \fCenter \lfalse$
 
-\RightLabel{$\lor$ left} 
+\RightLabel{$\lor$ left}
 \BinaryInf$ \Gamma_0, \Gamma_1, !A \lor !B \fCenter \lfalse $
 \end{prooftree}
 Since $\Gamma_0,\Gamma_1\subseteq \Gamma$ and $\Gamma \cup \{!A \lor
@@ -161,8 +161,8 @@ There is an $\Log{LK}$-!!{derivation} $\Pi_0$ and a finite set $\Gamma_0
 \AxiomC{}
 \RightLabel{$\Pi_0$}
 \Deduce$ \Gamma_0 \fCenter !A $
-\RightLabel{$\lor$ right} 
-\UnaryInf$ \Gamma_0 \fCenter !A \lor !B$ 
+\RightLabel{$\lor$ right}
+\UnaryInf$ \Gamma_0 \fCenter !A \lor !B$
 \end{prooftree}
 Therefore $\Gamma \Proves !A \lor !B$. The proof for when $\Gamma
 \Proves[\Log{LK}] !B$ is similar.}}
@@ -178,9 +178,9 @@ $\Gamma_0 \Sequent !A \land !B$. Consider
 \RightLabel{$\Pi_0$}
 \Deduce$ \Gamma_0, \fCenter !A \land !B$
 \Axiom$!A \fCenter !A$
-\RightLabel{$\land$ left} 
+\RightLabel{$\land$ left}
 \UnaryInf$!A \land !B \fCenter !A$
-\RightLabel{cut} 
+\RightLabel{cut}
 \BinaryInf$\Gamma_0 \fCenter !A$
 \end{prooftree}
 Hence, $\Gamma \Proves[\Log{LK}] !A$.  A similar !!{derivation} starting
@@ -202,7 +202,7 @@ with $!B \Sequent !B$ on the right side shows that $\Gamma
 \RightLabel{$\Pi_1$}
 \Deduce$ \Gamma_1, \fCenter !B$
 
-\RightLabel{$\land$ right} 
+\RightLabel{$\land$ right}
 \BinaryInf$\Gamma_0, \Gamma_1 \fCenter !A \land !B $
 \end{prooftree}
 Since $\Gamma_0 \cup \Gamma_1 \subseteq \Gamma$, we have $\Gamma
@@ -221,7 +221,7 @@ $\Pi_0$ of $\Gamma_0 \Sequent !A$ and $\Pi_1$ of $\Gamma_1 \Sequent !A
 \AxiomC{}
 \RightLabel{$\Pi_0$}
 \Deduce$ \Gamma_1 \fCenter !A \lif !B$
-\doubleLine 
+\doubleLine
 \UnaryInf$ \Gamma_0, \Gamma_1, \Gamma_2 \fCenter !A \lif !B$
 
 \AxiomC{}
@@ -229,13 +229,13 @@ $\Pi_0$ of $\Gamma_0 \Sequent !A$ and $\Pi_1$ of $\Gamma_1 \Sequent !A
 \Deduce$\Gamma_0 \fCenter !A $
 
 \AxiomC{$!B \fCenter !B$}
-\doubleLine 
+\doubleLine
 \UnaryInf$ \Gamma_0, !B \fCenter !B$
 
-\RightLabel{$\lif$ left} 
+\RightLabel{$\lif$ left}
 \BinaryInf$\Gamma_0, !A \lif !B \fCenter !B$
 
-\RightLabel{cut} 
+\RightLabel{cut}
 \BinaryInf$ \Gamma_0,\Gamma_1 \fCenter !B$
 \end{prooftree}
 Since $\Gamma_0 \cup \Gamma_1 \subseteq \Gamma$, this
@@ -306,7 +306,7 @@ and thus the eigenvariable condition is satisfied.
 \ollabel{thm:provability-quantifiers}
 \begin{tagenumerate}{prvEx,prvAll}
 \tagitem{prvEx}{If $\Gamma \Proves !A(t)$ then $\Gamma \Proves
-  \lexists[x][!A(x)]$.}{} 
+  \lexists[x][!A(x)]$.}{}
 
 \tagitem{prvAll}{If $\Gamma \Proves \lforall[x][!A(x)]$ then $\Gamma \Proves
   !A(t)$.}{}
@@ -317,7 +317,7 @@ and thus the eigenvariable condition is satisfied.
 \begin{tagenumerate}{prvEx,prvAll}
 \tagitem{prvEx}{Suppose $\Gamma \Proves !A(t)$. Then for some
   finite~$\Gamma_0 \subseteq \Gamma$, $\Log{LK}$ !!{derive}s $\Gamma_0
-  \Sequent !A(t)$. Add an $\lexists$ right inference to get 
+  \Sequent !A(t)$. Add an $\lexists$ right inference to get
   !!a{derivation} of $\Gamma_0 \Sequent \lexists[x][!A(x)]$.}{}
 
 \tagitem{prvAll}{Suppose $\Gamma \Proves \lnot !A(t)$. Then there is a

--- a/first-order-logic/sequent-calculus/proving-things.tex
+++ b/first-order-logic/sequent-calculus/proving-things.tex
@@ -10,7 +10,7 @@
 
 \olsection{Examples of \usetoken{P}{derivation}}
 
-\begin{ex} 
+\begin{ex}
 Give an $\Log{LK}$-derivation for the sequent $!A \land !B \Sequent !A$.
 
 We begin by writing the desired end-sequent at the bottom of the derivation.
@@ -42,7 +42,7 @@ We now have a correct $\Log{LK}$-derivation of the sequent $!A \land
 !B \Sequent !A$.
 \end{ex}
 
-\begin{ex} 
+\begin{ex}
 Give an $\Log{LK}$-derivation for the sequent $\lnot !A \lor !B
 \Sequent !A \lif !B$.
 
@@ -118,7 +118,7 @@ weakening away from finishing off this left branch as well.
 \end{prooftree}
 \end{ex}
 
-\begin{ex} 
+\begin{ex}
 Give an $\Log{LK}$-derivation of the sequent $\lnot !A \lor \lnot !B
 \Sequent \lnot (!A \land !B)$
 
@@ -136,7 +136,7 @@ branches for a moment:
 \begin{prooftree}
 \AxiomC{}
 \UnaryInf$!A \land !B, \lnot !A \lor \lnot !B \fCenter $
-\RightLabel{$\lnot$ right} 
+\RightLabel{$\lnot$ right}
 \UnaryInf$\lnot !A \lor \lnot !B \fCenter \lnot (!A \land !B)$
 \end{prooftree}
 Now we have a choice of whether to look at the $\land$ left or the
@@ -148,9 +148,9 @@ regards to $!A$ and $!B$, let's go with the former:
 \begin{prooftree}
 \AxiomC{}
 \UnaryInf$!A, \lnot !A \lor \lnot !B \fCenter $
-\RightLabel{$\land$ left} 
+\RightLabel{$\land$ left}
 \UnaryInf$!A \land !B, \lnot !A \lor \lnot !B \fCenter $
-\RightLabel{$\lnot$ right} 
+\RightLabel{$\lnot$ right}
 \UnaryInf$\lnot !A \lor \lnot !B \fCenter \lnot (!A \land !B)$
 \end{prooftree}
 Continuing to fill in the derivation, we see that we run into a problem:
@@ -161,11 +161,11 @@ Continuing to fill in the derivation, we see that we run into a problem:
 \RightLabel{?} \UnaryInf$!A \fCenter !B$
 \RightLabel{$\lnot$ left} \UnaryInf$ !A, \lnot !B \fCenter$
 
-\RightLabel{$\lor$ left} 
+\RightLabel{$\lor$ left}
 \BinaryInf$!A, \lnot !A \lor \lnot !B \fCenter $
-\RightLabel{$\land$ left} 
+\RightLabel{$\land$ left}
 \UnaryInf$!A \land !B, \lnot !A \lor \lnot !B \fCenter $
-\RightLabel{$\lnot$ right} 
+\RightLabel{$\lnot$ right}
 \UnaryInf$\lnot !A \lor \lnot !B \fCenter \lnot (!A \land !B)$
 \end{prooftree}
 The top of the right branch cannot be reduced any further, and it
@@ -180,9 +180,9 @@ had before and carrying out the $\lor$ left rule instead, we get
 \AxiomC{}
 \UnaryInf$!A \land !B, \lnot !B \fCenter $
 
-\RightLabel{$\lor$ left} 
+\RightLabel{$\lor$ left}
 \BinaryInf$!A \land !B, \lnot !A \lor \lnot !B \fCenter $
-\RightLabel{$\lnot$ right} 
+\RightLabel{$\lnot$ right}
 \UnaryInf$\lnot !A \lor \lnot !B \fCenter \lnot (!A \land !B)$
 \end{prooftree}
 Completing each branch as we've done before, we get
@@ -195,16 +195,16 @@ Completing each branch as we've done before, we get
 \RightLabel{$\land$ left} \UnaryInf$!A \land !B \fCenter !B$
 \RightLabel{$\lnot$ left} \UnaryInf$!A \land !B, \lnot !B \fCenter $
 
-\RightLabel{$\lor$ left} 
+\RightLabel{$\lor$ left}
 \BinaryInf$!A \land !B, \lnot !A \lor \lnot !B \fCenter $
-\RightLabel{$\lnot$ right} 
+\RightLabel{$\lnot$ right}
 \UnaryInf$\lnot !A \lor \lnot !B \fCenter \lnot (!A \land !B)$
 \end{prooftree}
 (We could have carried out the $\land$ rules lower than the $\lnot$
 rules in these steps and still obtained a correct derivation).
 \end{ex}
 
-\begin{ex} 
+\begin{ex}
 Give an $\Log{LK}$-derivation of the sequent $\lexists[x][\lnot !A(x)]
 \Sequent \lnot \lforall[x][!A(x)]$.
 
@@ -234,18 +234,18 @@ later, so we'll do that one first.
 \begin{prooftree}
 \AxiomC{}
 \UnaryInf$ \lnot !A(a) \fCenter \lnot \lforall[x][!A(x)]$
-\RightLabel{$\lexists$ left} 
+\RightLabel{$\lexists$ left}
 \UnaryInf$ \lexists[x][\lnot !A(x)] \fCenter \lnot \lforall[x][!A(x)]$
 \end{prooftree}
 Applying the $\lnot$ left and right rules to eliminate the $\lnot$ signs, we get
 \begin{prooftree}
 \AxiomC{}
 \UnaryInf$\lforall[x][!A(x)] \fCenter !A(a)$
-\RightLabel{$\lnot$ right} 
+\RightLabel{$\lnot$ right}
 \UnaryInf$ \fCenter \lnot \lforall[x][!A(x)], !A(a)$
-\RightLabel{$\lnot$ left} 
+\RightLabel{$\lnot$ left}
 \UnaryInf$ \lnot !A(a) \fCenter \lnot \lforall[x] !A(x)$
-\RightLabel{$\lexists$ left} 
+\RightLabel{$\lexists$ left}
 \UnaryInf$ \lexists[x] \lnot !A(x) \fCenter \lnot \lforall[x] !A(x)$
 \end{prooftree}
 At this point, our only option is to carry out the $\forall$ left
@@ -255,13 +255,13 @@ sequent (of the form $!A(a) \Sequent !A(a)$), so we should choose $a$
 as our argument for $!A$ when we apply the rule.
 \begin{prooftree}
 \Axiom$!A(a) \fCenter !A(a)$
-\RightLabel{$\lforall$ left} 
+\RightLabel{$\lforall$ left}
 \UnaryInf$\lforall[x][!A(x)] \fCenter !A(a)$
-\RightLabel{$\lnot$ right} 
+\RightLabel{$\lnot$ right}
 \UnaryInf$ \fCenter \lnot \lforall[x][!A(x)], !A(a)$
-\RightLabel{$\lnot$ left} 
+\RightLabel{$\lnot$ left}
 \UnaryInf$ \lnot !A(a) \fCenter \lnot \lforall[x][!A(x)]$
-\RightLabel{$\lexists$ left} 
+\RightLabel{$\lexists$ left}
 \UnaryInf$ \lexists[x][ \lnot !A(x)] \fCenter \lnot \lforall[x][!A(x)]$
 \end{prooftree}
 It is important, especially when dealing with quantifiers, to double

--- a/first-order-logic/sequent-calculus/rules-and-proofs.tex
+++ b/first-order-logic/sequent-calculus/rules-and-proofs.tex
@@ -27,7 +27,7 @@ The intuitive idea behind a sequent is: if all of the antecedent
 holds. That is, if $\Gamma = \{ \Gamma_1, \dots, \Gamma_m\}$ and
 $\Delta = \{ \Delta_1, \dots, \Delta_n\}$, then $\Gamma \Sequent
 \Delta$ holds iff
-\[ 
+\[
 (\Gamma_1 \land \cdots \land \Gamma_m) \lif (\Delta_1 \lor \cdots \lor
 \Delta_n) \] holds.
 
@@ -187,7 +187,7 @@ $\forall$ right inference.
 
 \[
 \Axiom$ !A(a), \Gamma \fCenter \Delta $
-\RightLabel{$\lexists$ left}   
+\RightLabel{$\lexists$ left}
 \UnaryInf$ \lexists[x][!A(x)], \Gamma \fCenter \Delta$
 \DisplayProof
 \quad
@@ -210,7 +210,7 @@ is a constant. This has historical reasons.
 
 In $\lexists$ right and $\lforall$ left there are no restrictions, and
 the term~$t$ can be anything, so we do not have to worry about any
-conditions.  However, because the $t$ may appear elsewhere in the
+conditions. However, because the $t$ may appear elsewhere in the
 sequent, the values of~$t$ for which the sequent is satisfied are
 constrained. On the other hand, in the $\lexists$ left and $\lforall$
 right rules, the eigenvariable condition requires that $a$ does not

--- a/first-order-logic/sequent-calculus/soundness.tex
+++ b/first-order-logic/sequent-calculus/soundness.tex
@@ -66,26 +66,26 @@ valid.
 First, we consider the possible inferences with only one premise
 $\Gamma' \Sequent \Delta'$.
 \begin{enumerate}
-\item The last inference is a weakening. Then $\Gamma' \subseteq
+\item The last inference is a weakening.  Then $\Gamma' \subseteq
   \Gamma$ and $\Delta = \Delta'$ if it's a weakening on the left, or
   $\Gamma = \Gamma'$ and $\Delta' \subseteq \Delta$ if it's a weaking
   on the right.  In either case, $\Delta' \subseteq \Delta$ and
   $\Gamma' \subseteq \Gamma$.  If $\Sat/{M}{!E}$ for some $!E \in
   \Gamma'$, then, since $\Gamma' \subseteq \Gamma$, $!E \in \Gamma$ as
-  well, and so $\Sat/{M}{!E}$ for the same $!E \in \Gamma$. Similarly,
+  well, and so $\Sat/{M}{!E}$ for the same $!E \in \Gamma$.  Similarly,
   if $\Sat{M}{!E}$ for some $!E \in \Delta'$, as $!E \in \Delta$,
-  $\Sat{M}{!E}$ for some $!E \in \Delta$. Since $\Gamma' \Sequent
+  $\Sat{M}{!E}$ for some $!E \in \Delta$.  Since $\Gamma' \Sequent
   \Delta'$ is valid, one of these cases obtains for every~$\Struct
   M$. Consequently, $\Gamma \Sequent \Delta$ is valid.
 \item The last inference is $\lnot$~left: Then for some $!A \in
   \Delta'$, $\lnot !A \in \Gamma$.  Also, $\Gamma' \subseteq \Gamma$,
-  and $\Delta' \setminus \{!A\} \subseteq \Delta$. 
+  and $\Delta' \setminus \{!A\} \subseteq \Delta$.
 
   If $\Sat{M}{!A}$, then $\Sat/{M}{\lnot !A}$, and since $\lnot !A
   \in \Gamma$, $\Struct M$ satisfies $\Gamma \Sequent \Delta$.  Since
   $\Gamma' \Sequent \Delta'$ is valid, if $\Sat/{M}{!A}$, then either
   $\Sat/{M}{!E}$ for some $!E \in \Gamma'$ or $\Sat{M}{!E}$ for some
-  $!E \in \Delta'$ different from~$!A$. Consequently, $\Sat/{M}{!E}$
+  $!E \in \Delta'$ different from~$!A$.  Consequently, $\Sat/{M}{!E}$
   for some $!E \in \Gamma$ (since $\Gamma' \subseteq \Gamma$) or
   $\Sat{M}{!E}$ for some $!E \in \Delta'$ different from~$!A$ (since
   $\Delta' \setminus \{!A\} \subseteq \Delta$).
@@ -93,31 +93,31 @@ $\Gamma' \Sequent \Delta'$.
 \item The last inference is $\land$~left: There are two variants: $!A
   \land !B$ may be inferred on the left from $!A$ or from $!B$ on the
   left side of the premise.  In the first case, $!A \in \Gamma'$.
-  Consider a !!{structure}~$\Struct M$. Since $\Gamma' \Sequent
+  Consider a !!{structure}~$\Struct M$.  Since $\Gamma' \Sequent
   \Delta'$ is valid, (a) $\Sat/{M}{!A}$, (b) $\Sat/{M}{!E}$ for some
   $!E \in \Gamma' \setminus \{!A\}$, or (c)~$\Sat{M}{!E}$ for some $!E
-  \in \Delta'$.  In case (a), $\Sat/{M}{!A \land !B}$. In case (b),
+  \in \Delta'$.  In case (a), $\Sat/{M}{!A \land !B}$.  In case (b),
   there is an $!E \in \Gamma \setminus \{!A \land !B\}$ such that
   $\Sat/{M}{!E}$, since $\Gamma' \setminus \{!A\} \subseteq \Gamma
-  \setminus \{!A \land !B\}$. In case (c), there is a $!E \in \Delta$
-  such that $\Sat{M}{!E}$, as $\Delta = \Delta'$. So in each case,
-  $\Struct M$ satisfies $!A \land !B, \Gamma \Sequent \Delta$. Since
-  $\Struct M$ was arbitrary, $\Gamma \Sequent \Delta$ is valid. The
+  \setminus \{!A \land !B\}$.  In case (c), there is a $!E \in \Delta$
+  such that $\Sat{M}{!E}$, as $\Delta = \Delta'$.  So in each case,
+  $\Struct M$ satisfies $!A \land !B, \Gamma \Sequent \Delta$.  Since
+  $\Struct M$ was arbitrary, $\Gamma \Sequent \Delta$ is valid.  The
   case where $!A \land !B$ is inferred from $!B$ is handled the same,
   changing $!A$ to $!B$.
 \item The last inference is $\lor$~right: There are two variants: $!A
   \lor !B$ may be inferred on the right from $!A$ or from $!B$ on the
   right side of the premise.  In the first case, $!A \in \Delta'$.
-  Consider a !!{structure}~$\Struct M$. Since $\Gamma' \Sequent
+  Consider a !!{structure}~$\Struct M$.  Since $\Gamma' \Sequent
   \Delta'$ is valid, (a) $\Sat{M}{!A}$, (b) $\Sat/{M}{!E}$ for some
   $!E \in \Gamma'$, or (c)~$\Sat{M}{!E}$ for some $!E \in \Delta'
-  \setminus \{!A\}$.  In case (a), $\Sat{M}{!A \lor !B}$. In case (b),
+  \setminus \{!A\}$.  In case (a), $\Sat{M}{!A \lor !B}$.  In case (b),
   there is $!E \in \Gamma$ such that $\Sat/{M}{!E}$, as $\Gamma =
-  \Gamma'$. In case (c), there is an $!E \in \Delta$ such that
-  $\Sat{M}{!E}$, since $\Delta' \setminus \{!A\} \subseteq \Delta$. So
+  \Gamma'$.  In case (c), there is an $!E \in \Delta$ such that
+  $\Sat{M}{!E}$, since $\Delta' \setminus \{!A\} \subseteq \Delta$.  So
   in each case, $\Struct M$ satisfies $!A \land !B, \Gamma \Sequent
-  \Delta$. Since $\Struct M$ was arbitrary, $\Gamma \Sequent \Delta$
-  is valid. The case where $!A \lor !B$ is inferred from $!B$ is
+  \Delta$.  Since $\Struct M$ was arbitrary, $\Gamma \Sequent \Delta$
+  is valid.  The case where $!A \lor !B$ is inferred from $!B$ is
   handled the same, changing $!A$ to $!B$.
 \item The last inference is $\lif$~right: Then $!A \in \Gamma'$, $!B
   \in \Delta'$, $\Gamma' \setminus \{!A\} \subseteq \Gamma$ and
@@ -126,32 +126,32 @@ $\Gamma' \Sequent \Delta'$.
   $\Sat/{M}{!A}$, (b) $\Sat{M}{!B}$, (c) $\Sat/{M}{!E}$ for some~$~!E
   \in \Gamma' \setminus \{!A\}$, or $\Sat{M}{!E}$ for some $!E \in
   \Delta' \setminus \{!B\}$.  In cases (a) and (b), $\Sat{M}{!A \lif
-    !B}$. In case (c), for some $!E \in \Gamma$, $\Sat/{M}{!E}$. In
-  case (d), for some $!E \in \Delta$, $\Sat{M}{!E}$. In each case,
-  $\Struct M$ satisfies $\Gamma \Sequent \Delta$. Since $\Struct M$
+    !B}$.  In case (c), for some $!E \in \Gamma$, $\Sat/{M}{!E}$. In
+  case (d), for some $!E \in \Delta$, $\Sat{M}{!E}$.  In each case,
+  $\Struct M$ satisfies $\Gamma \Sequent \Delta$.  Since $\Struct M$
   was arbitrary, $\Gamma \Sequent \Delta$ is valid.
 \item The last inference is $\forall$~left: Then there is a
   !!{formula}~$!A(x)$ and a ground term~$t$ such that $!A(t) \in
   \Gamma'$, $\lforall[x][!A(x)] \in \Gamma$, and $\Gamma' \setminus
   \{!A(t)\} \subseteq \Gamma$.  Consider a !!{structure}~$\Struct
-  M$. Since $\Gamma' \Sequent \Delta'$ is valid, (a)
+  M$.  Since $\Gamma' \Sequent \Delta'$ is valid, (a)
   $\Sat/{M}{!A(t)}$, (b) $\Sat/{M}{!E}$ for some $!E \in \Gamma'
   \setminus \{!A(t)\}$, or (c)~$\Sat{M}{!E}$ for some $!E \in
   \Delta'$.  In case (a), $\Sat/{M}{\lforall[x][!A(x)]}$. In case (b),
   there is an $!E \in \Gamma \setminus \{!A(t)\}$ such that
-  $\Sat/{M}{!E}$. In case (c), there is a $!E \in \Delta$ such that
-  $\Sat{M}{!E}$, as $\Delta = \Delta'$. So in each case, $\Struct M$
-  satisfies $\Gamma \Sequent \Delta$. Since $\Struct M$ was arbitrary,
+  $\Sat/{M}{!E}$.  In case (c), there is a $!E \in \Delta$ such that
+  $\Sat{M}{!E}$, as $\Delta = \Delta'$.  So in each case, $\Struct M$
+  satisfies $\Gamma \Sequent \Delta$.  Since $\Struct M$ was arbitrary,
   $\Gamma \Sequent \Delta$ is valid.
 \item The last inference is $\lexists$~right: Exercise.
 \item The last inference is $\forall$~right: Then there is a
   !!{formula}~$!A(x)$ and a !!{constant}~$a$ such that $!A(a) \in
   \Delta'$, $\lforall[x][!A(x)] \in \Delta$, and $\Delta' \setminus
   \{!A(a)\} \subseteq \Delta$.  Furthermore, $a \notin \Gamma \cup
-  \Delta$.  Consider a !!{structure}~$\Struct M$. Since $\Gamma'
+  \Delta$.  Consider a !!{structure}~$\Struct M$.  Since $\Gamma'
   \Sequent \Delta'$ is valid, (a) $\Sat{M}{!A(a)}$, (b) $\Sat/{M}{!E}$
   for some $!E \in \Gamma'$, or (c)~$\Sat{M}{!E}$ for some $!E \in
-  \Delta' \setminus \{!A(a)\}$.  
+  \Delta' \setminus \{!A(a)\}$.
 
   First, suppose (a) is the case but neither (b) nor (c), i.e.,
   $\Sat{M}{!E}$ for all $!E \in \Gamma'$ and $\Sat/{M}{!E}$ for all
@@ -159,7 +159,7 @@ $\Gamma' \Sequent \Delta'$.
   $\Sat{M}{!A(a)}$ and that $\Struct M$ does not satisfy $\Gamma'
   \Sequent \Delta' \setminus \{!A(a)\}$.  Since $a \notin \Gamma \cup
   \Delta$, also $a \notin \Gamma' \cup (\Delta' \setminus
-  \{!A(a)\})$. Thus, if $\Struct{M'}$ is like $\Struct M$ except that
+  \{!A(a)\})$.  Thus, if $\Struct{M'}$ is like $\Struct M$ except that
   $\Assign{a}{M} \neq \Assign{a}{M'}$, $\Struct{M'}$ also does not
   satisfy $\Gamma' \Sequent \Delta' \setminus \{!A(a)\}$ by
   extensionality.  But since $\Gamma' \Sequent \Delta'$ is valid, we
@@ -167,25 +167,25 @@ $\Gamma' \Sequent \Delta'$.
 
   We now show that $\Sat{M}{\lforall[x][!A(x)]}$.  To do this, we have
   to show that for every variable assignment~$s$,
-  $\Sat{M}{\lforall[x][!A(x)]}[s]$. This in turn means that for every
+  $\Sat{M}{\lforall[x][!A(x)]}[s]$.  This in turn means that for every
   $x$-variant $s'$ of $s$, we must have $\Sat{M}{!A(x)}[s']$.  So
   consider any variable assignment~$s$ and let $s'$ be an $x$-variant
-  of~$s$. Since $\Gamma'$ and $\Delta'$ consist entirely of sentences,
+  of~$s$.  Since $\Gamma'$ and $\Delta'$ consist entirely of sentences,
   $\Sat{M}{!E}[s]$ iff $\Sat{M}{!E}[s']$ iff $\Sat{M}{!E}$ for all
   $!E \in \Gamma' \cup \Delta'$.  Let $\Struct M'$ be like $\Struct M$
   except that $\Assign{a}{M'} = s'(x)$.  Then $\Sat{M}{!A(x)}[s']$ iff
-  $\Sat{M'}{!A(a)}$ (as $!A(x)$ does not contain~$a$). Since we've
+  $\Sat{M'}{!A(a)}$ (as $!A(x)$ does not contain~$a$).  Since we've
   already established that $\Sat{M'}{!A(a)}$ for all $\Struct M'$
   which differ from $\Struct M$ at most in what they assign to~$a$,
   this means that $\Sat{M}{!A(x)}[s']$.  Thus weve shown that
-  $\Sat{M}{\lforall[x][!A(x)]}[s]$. Since $s$ is an arbitrary variable
+  $\Sat{M}{\lforall[x][!A(x)]}[s]$.  Since $s$ is an arbitrary variable
   assignment and $\lforall[x][!A(x)]$ is a sentence, then
   $\Sat{M}{\lforall[x][!A(x)]}$.
 
   If (b) is the case, there is a $!E \in \Gamma$ such that
   $\Sat/{M}{!E}$, as $\Gamma = \Gamma'$.  If (c) is the case, there is
   an $!E \in \Delta' \setminus \{!A(a)\}$ such that $\Sat{M}{!E}$.  So
-  in each case, $\Struct M$ satisfies $\Gamma \Sequent \Delta$. Since
+  in each case, $\Struct M$ satisfies $\Gamma \Sequent \Delta$.  Since
   $\Struct M$ was arbitrary, $\Gamma \Sequent \Delta$ is valid.
 \item The last inference is $\lexists$~left: Exercise.
 \end{enumerate}
@@ -205,7 +205,7 @@ $\lor$~left, $\land$~right, and $\lif$~left.
   \setminus \{!A\} \Sequent \Lambda'$.  But $\Pi' \setminus \{!A\}
   \subseteq \Gamma$ and $\Lambda' \subseteq \Delta$, so $\Struct M$
   also satisfies $\Gamma \Sequent \Delta$.
-\item The last inference is $\land$~right. The premises are $\Gamma
+\item The last inference is $\land$~right.  The premises are $\Gamma
   \Sequent \Delta'$ and $\Gamma \Sequent \Delta''$, where $!A \in
   \Delta'$ an $!B \in \Delta''$.  By induction hypothesis, both are
   valid.  Consider a !!{structure}~$\Struct M$.  We have two cases:
@@ -220,11 +220,11 @@ $\lor$~left, $\land$~right, and $\lif$~left.
   $\Struct M$ satisfies $\Gamma \Sequent \Delta$ since $!A \land !B
   \in \Delta$.
 \item The last inference is $\lor$~left: Exercise.
-\item The last inference is $\lif$~left. The premises are $\Gamma
+\item The last inference is $\lif$~left.  The premises are $\Gamma
   \Sequent \Delta'$ and $\Gamma' \Sequent \Delta$, where $!A \in
   \Delta'$ an $!B \in \Gamma'$.  By induction hypothesis, both are
   valid.  Consider a !!{structure}~$\Struct M$.  We have two cases:
-  (a) $\Sat/{M}{!A \lif !B}$ or (b) $\Sat{M}{!A \lif !B}$. In case
+  (a) $\Sat/{M}{!A \lif !B}$ or (b) $\Sat{M}{!A \lif !B}$.  In case
   (a), either $\Sat/{M}{!A}$ or $\Sat{M}{!B}$.  In the former case, in
   order for $\Struct M$ to satisfy $\Gamma \Sequent \Delta'$, it must
   already satisfy $\Gamma \Sequent \Delta' \setminus \{!A\}$.  In the
@@ -252,7 +252,7 @@ If $\Gamma \Proves !A$ then $\Gamma \Entails !A$.
 
 \begin{proof}
 If $\Gamma \Proves !A$ then for some finite subset $\Gamma_0 \subseteq
-\Gamma$, there is !!a{derivation} of $\Gamma_0 \Sequent !A$. By
+\Gamma$, there is !!a{derivation} of $\Gamma_0 \Sequent !A$.  By
 \olref{sequent-soundness}, every !!{structure} $\Struct M$ either
 makes some $!B \in \Gamma_0$ false or makes $!A$ true.  Hence, if
 $\Sat{M}{\Gamma_0}$ then also $\Sat{M}{!A}$.
@@ -264,10 +264,10 @@ If $\Gamma$ is satisfiable, then it is consistent.
 \end{cor}
 
 \begin{proof}
-We prove the contrapositive. Suppose that $\Gamma$ is not
-consistent. Then $\Gamma \Proves \lfalse$, i.e., there is a finite
+We prove the contrapositive.  Suppose that $\Gamma$ is not
+consistent.  Then $\Gamma \Proves \lfalse$, i.e., there is a finite
 $\Gamma_0 \subseteq \Gamma$ and !!a{derivation} of $\Gamma_0 \Sequent
-\lfalse$. By \olref{sequent-soundness}, $\Gamma_0 \Sequent \lfalse$ is
+\lfalse$.  By \olref{sequent-soundness}, $\Gamma_0 \Sequent \lfalse$ is
 valid.  Since $\Sat/{M}{\lfalse}$ for every !!{structure}~$\Struct M$,
 for $\Struct M$ to satisfy $\Gamma_0 \Sequent \lfalse$ there must be
 an $!E \in \Gamma_0$ so that $\Sat/{M}{!E}$, and since $\Gamma_0

--- a/first-order-logic/syntax-and-semantics/extensionality.tex
+++ b/first-order-logic/syntax-and-semantics/extensionality.tex
@@ -25,10 +25,10 @@ of the language appearing in a sentence~$!A$ and have the same domain,
 \end{explain}
 
 \begin{prop}[Extensionality]
-Let $!A$ be a sentence, and $\Struct M$ and $\Struct M'$ be !!{structure}s. 
-If $\Assign{c}{M} = \Assign{c}{M'}$, $\Assign{R}{M}=\Assign{R}{M'}$, and 
-$\Assign{f}{M} = \Assign{f}{M'}$ for every !!{constant}~$c$, relation 
-symbol~$R$, and !!{function} $f$ occurring in~$!A$, then $\Sat{M}{!A}$ 
+Let $!A$ be a sentence, and $\Struct M$ and $\Struct M'$ be !!{structure}s.
+If $\Assign{c}{M} = \Assign{c}{M'}$, $\Assign{R}{M}=\Assign{R}{M'}$, and
+$\Assign{f}{M} = \Assign{f}{M'}$ for every !!{constant}~$c$, relation
+symbol~$R$, and !!{function} $f$ occurring in~$!A$, then $\Sat{M}{!A}$
 iff $\Sat{M'}{!A}$.
 \end{prop}
 
@@ -43,7 +43,7 @@ by~$s'(x) = \Value{t'}{M}[s]$. Then $\Value{\Subst{t}{t'}{x}}{M}[s] =
 \end{prop}
 
 \begin{proof}
-By induction on~$t$. 
+By induction on~$t$.
 \begin{enumerate}
 \item If $t$ is a constant, say, $t\ident c$, then $\Subst{t}{t'}{x} =
   c$, and $\Value{c}{M}[s] = \Assign{c}{M} = \Value{c}{M}[s']$.
@@ -52,19 +52,19 @@ By induction on~$t$.
   $\Subst{t}{t'}{x} = y$, and $\Value{y}{M}[s] = \Value{y}{M}[s']$
   since $s' \sim_x s$.
 
-\item If $t \ident x$, then $\Subst{t}{t'}{x} = t'$.  But
+\item If $t \ident x$, then $\Subst{t}{t'}{x} = t'$. But
   $\Value{x}{M}[s'] = \Value{t'}{M}[s]$ by definition of~$s'$.
 
 \item If $t \ident \Atom{f}{t_1,\dots,t_n}$ then we have:
 \begin{align*}
-\Value{\Subst{t}{t'}{x}}{M}[s] & = 
+\Value{\Subst{t}{t'}{x}}{M}[s] & =
 \Value{\Atom{f}{\Subst{t_1}{t'}{x}, \dots, \Subst{t_n}{t'}{x}}}{M}[s]
     \text{ by definition of $\Subst{t}{t'}{x}$}\\
-& = \Assign{f}{M}(\Value{\Subst{t_1}{t'}{x}}{M}[s], \dots, 
-   \Value{\Subst{t_n}{t'}{x}}{M}[s]) 
+& = \Assign{f}{M}(\Value{\Subst{t_1}{t'}{x}}{M}[s], \dots,
+   \Value{\Subst{t_n}{t'}{x}}{M}[s])
     \text{ by definition of $\Value{\Atom{f}{\dots}}{M}[s]$}\\
-& = \Assign{f}{M}(\Value{t_1}{M}[s'], \dots, 
-   \Value{t_n}{M}[s']) 
+& = \Assign{f}{M}(\Value{t_1}{M}[s'], \dots,
+   \Value{t_n}{M}[s'])
     \text{ by induction hypothesis}\\
 & = \Value{t}{M}[s']
     \text{ by definition of $\Value{\Atom{f}{\dots}}{M}[s']$}

--- a/first-order-logic/syntax-and-semantics/first-order-languages.tex
+++ b/first-order-logic/syntax-and-semantics/first-order-languages.tex
@@ -65,7 +65,7 @@ first-order logic:
 Most of our definitions and results will be formulated for the full
 standard language of first-order logic.  However, depending on the
 application, we may also restrict the language to only a few
-!!{predicate}s, !!{constant}s, and !!{function}s.  
+!!{predicate}s, !!{constant}s, and !!{function}s.
 
 \begin{ex}
 The language~$\Lang L_A$ of arithmetic contains a single two-place
@@ -95,8 +95,8 @@ above, we also use the following \emph{defined} symbols:
 \startycommalist
   \iftag{defNot}{\ycomma $\lnot$ (negation)}{}%
   \iftag{defAnd}{\ycomma $\land$ (conjunction)}{}%
-  \iftag{defOr}{\ycomma $\lor$ (disjunction)}{}% 
-  \iftag{defIf}{\ycomma $\lif$ (!!{conditional})}{}% 
+  \iftag{defOr}{\ycomma $\lor$ (disjunction)}{}%
+  \iftag{defIf}{\ycomma $\lif$ (!!{conditional})}{}%
   \iftag{defIff}{\ycomma $\liff$ (!!{biconditional})}{}%
   \iftag{defAll}{\ycomma $\lforall$ (universal quantifier)}{}%
   \iftag{defEx}{\ycomma $\lexists$ (existential quantifier)}{}%
@@ -124,13 +124,13 @@ for ``conjunction''.  Commonly used symbols for the ``conditional'' or
 ``implication'' are $\rightarrow$, $\Rightarrow$, and $\supset$.
 \iftag{prvIff,defIff}{Symbols for ``biconditional,'' ``bi-implication,''
   or ``(material) equivalence'' are $\leftrightarrow$,
-  $\Leftrightarrow$, and $\equiv$.}{} 
+  $\Leftrightarrow$, and $\equiv$.}{}
 \iftag{prvFalse,defFalse}{The $\lfalse$ symbol is variously called
   ``falsity,'' ``falsum,'', ``absurdity,'', or ``bottom.''}{}
 \iftag{prvTrue,defTrue}{The $\ltrue$ symbol is variously called
   ``truth,'' ``verum,'', or ``top.''}{}
 
-It is very common to use lower case letters (e.g., $a$, $b$, $c$) from
+It is conventional to use lower case letters (e.g., $a$, $b$, $c$) from
 the beginning of the Latin alphabet for !!{constant}s (sometimes called
 names), and lower case letters from the end (e.g., $x$, $y$, $z$) for
 !!{variable}s. Quantifiers combine with !!{variable}s, e.g., $x$;
@@ -141,7 +141,7 @@ x)$, $(Ex)$, $\Sigma x$, $\bigvee_x$ for the existential quantifier.
 
 \begin{explain}
 We might treat all the propositional operators and both quantifiers as
-primitive symbols of the language. We might instead choose a smaller
+primitive symbols of the language.  We might instead choose a smaller
 stock of primitive symbols and treat the other !!{operator}s as
 defined. ``Truth functionally complete'' sets of Boolean operators
 include $\{ \lnot, \lor \}$, $\{ \lnot, \land \}$, and $\{ \lnot,
@@ -150,7 +150,7 @@ expressively complete first-order language.
 
 You may be familiar with two other !!{operator}s: the Sheffer
 stroke~$|$ (named after Henry Sheffer), and Peirce's
-arrow~$\downarrow$, also known as Quine's dagger. When given their
+arrow~$\downarrow$, also known as Quine's dagger.  When given their
 usual readings of ``nand'' and ``nor'' (respectively), these operators
 are truth functionally complete by themselves.
 \end{explain}

--- a/first-order-logic/syntax-and-semantics/main-operator.tex
+++ b/first-order-logic/syntax-and-semantics/main-operator.tex
@@ -21,7 +21,7 @@ the main operator of $(!A \lor !B)$ is $\lor$, etc.
 
 \begin{defn}[!!^{main operator}]
 \ollabel{def:main-op}
-The \emph{!!{main operator}} of a !!{formula}~$!A$ is 
+The \emph{!!{main operator}} of a !!{formula}~$!A$ is
 defined as follows:
 \begin{enumerate}
 \item \indcase*{!A}{!A}{$\indfrm$ has no !!{main operator}.}
@@ -76,7 +76,7 @@ We call !!{formula}s by the following names depending on which symbol their
 \begin{tabular}{c | c | c}
 !!^{main operator} & Type of !!{formula} & Example\\
 \hline
-none & atomic (!!{formula}) & 
+none & atomic (!!{formula}) &
 \iftag{prvFalse}{$\lfalse$,}{}
 \iftag{prvTrue}{$\ltrue$,}{}
 $\Atom{R}{t_1, \dots, t_n}$,

--- a/first-order-logic/syntax-and-semantics/satisfaction.tex
+++ b/first-order-logic/syntax-and-semantics/satisfaction.tex
@@ -6,7 +6,7 @@
 
 \begin{document}
 
-\olfileid{fol}{syn}{sat} 
+\olfileid{fol}{syn}{sat}
 
 \olsection{Satisfaction of a \printtoken{S}{formula} in a
   \printtoken{S}{structure}}
@@ -101,7 +101,7 @@ $\Sat/{M}{!A}[s]$ to mean ``not $\Sat{M}{!A}[s]$.'')
 \item \indcase{!A}{\eq[t_1][t_2]}{$\Sat{M}{\indfrm}[s]$ iff
   $\Value{t_1}{M}[s] = \Value{t_2}{M}[s]$.}
 
-\tagitem{prvNot}{% 
+\tagitem{prvNot}{%
   \indcase{!A}{\lnot !B}{$\Sat{M}{\indfrm}[s]$ iff
     $\Sat/{M}{!B}[s]$.}}{}
 
@@ -117,7 +117,7 @@ $\Sat/{M}{!A}[s]$ to mean ``not $\Sat{M}{!A}[s]$.'')
   \indcase{!A}{(!B \lif !C)}{$\Sat{M}{\indfrm}[s]$ iff $\Sat/{M}{!B}[s]$
     or $\Sat{M}{!C}[s]$ (or both).}}{}
 
-\tagitem{prvIff}{% 
+\tagitem{prvIff}{%
   \indcase{!A}{(!B \liff !C)}{$\Sat{M}{\indfrm}[s]$ iff either both
     $\Sat{M}{!B}[s]$ and $\Sat{M}{!C}[s]$, or neither $\Sat{M}{!B}[s]$
     nor $\Sat{M}{!C}[s]$.}}{}
@@ -126,7 +126,7 @@ $\Sat/{M}{!A}[s]$ to mean ``not $\Sat{M}{!A}[s]$.'')
   \indcase{!A}{\lforall[x][!B]}{$\Sat{M}{\indfrm}[s]$ iff for every
     $x$-variant $s'$ of $s$, $\Sat{M}{!B}[s']$.}}{}
 
-\tagitem{prvEx}{% 
+\tagitem{prvEx}{%
   \indcase{!A}{\lexists[x][!B]}{$\Sat{M}{\indfrm}[s]$ iff there is an
     $x$-variant $s'$ of $s$ so that $\Sat{M}{!B}[s']$.}}{}
 \end{enumerate}
@@ -188,9 +188,9 @@ $\Sat{M}{!A}[s']$.
 
 \begin{proof}
 We use induction on the complexity of $!A$. For the base case, where
-$!A$ is atomic, $!A$ can be: 
-\iftag{prvTrue}{$\ltrue$,}{} 
-\iftag{prvFalse}{$\lfalse$,}{} 
+$!A$ is atomic, $!A$ can be:
+\iftag{prvTrue}{$\ltrue$,}{}
+\iftag{prvFalse}{$\lfalse$,}{}
 $R(t_1 \ldots t_k)$ for a $k$-place predicate $R$ and terms
 $t_1,\ldots,t_k$, or $\eq[t_1][t_2]$ for terms $t_1$ and $t_2$.
 
@@ -292,7 +292,7 @@ By induction, we get that $\Sat{M}{!A}[s]$ iff $\Sat{M}{!A}[s']$
 whenever $x_1$, \dots, $x_n$ are the only free !!{variable}s in $!A$ and
 $s(x_i)=s'(x_i)$ for $i=1$, \dots,~$n$.
 \end{proof}
- 
+
 \begin{probtag}{probNot,probOr,probAnd,probIf,probEx,probAll}
 Complete the proof of \olref[fol][syn][sat]{prop:satindep}.
 \end{probtag}
@@ -349,11 +349,11 @@ that $\Assign{c}{M[a/c]} = a$. Define $\Struct M \VDash !A$ for
 \item \indcase{!A}{\eq[d_1][d_2]}{$\Struct M \VDash \indfrm$ iff
   $\Assign{d_1}{M} = \Assign{d_2}{M}$.}
 
-\tagitem{prvNot}{% 
+\tagitem{prvNot}{%
   \indcase{!A}{\lnot !B}{$\Struct{M} \VDash \indfrm$ iff
     not $\Struct{M} \VDash {!B}$.}}{}
 
-\tagitem{prvAnd}{% 
+\tagitem{prvAnd}{%
   \indcase{!A}{(!B \land !C)}{$\Struct{M} \VDash
     \indfrm$ iff $\Struct{M} \VDash!B$ and $\Struct{M} \VDash !C$.}}{}
 
@@ -362,10 +362,10 @@ that $\Assign{c}{M[a/c]} = a$. Define $\Struct M \VDash !A$ for
     $\Struct{M} \VDash !A$ or $\Struct{M} \VDash !B$ (or both).}}{}
 
 \tagitem{prvIf}{%
-  \indcase{!A}{(!B \lif !C)}{$\Struct{M} \VDash \indfrm$ iff 
+  \indcase{!A}{(!B \lif !C)}{$\Struct{M} \VDash \indfrm$ iff
     not $\Struct {M} \VDash !B$ or $\Struct M \VDash !C$ (or both).}}{}
 
-\tagitem{prvIff}{% 
+\tagitem{prvIff}{%
   \indcase{!A}{(!B \liff !C)}{$\Struct{M} \VDash {\indfrm}$ iff either
     both $\Struct{M} \VDash {!B}$ and $\Struct{M} \VDash {!C}$, or
     neither $\Struct{M} \VDash {!B}$ nor $\Struct{M} \VDash {!C}$.}}{}
@@ -375,7 +375,7 @@ that $\Assign{c}{M[a/c]} = a$. Define $\Struct M \VDash !A$ for
     all $a \in \Domain{M}$, $\Struct{M[a/c]} \VDash \Subst{!B}{c}{x}$,
     if $c$ does not occur in~$!B$.}}{}
 
-\tagitem{prvEx}{% 
+\tagitem{prvEx}{%
   \indcase{!A}{\lexists[x][!B]}{$\Struct{M} \VDash
   {\indfrm}$ iff there is an $a \in \Domain M$ such that
   $\Struct{M[a/c]} \VDash \Subst{!B}{c}{x}$, if $c$ does not occur

--- a/first-order-logic/syntax-and-semantics/semantic-notions.tex
+++ b/first-order-logic/syntax-and-semantics/semantic-notions.tex
@@ -19,7 +19,7 @@ how the non-logical symbols in it are interpreted.  Valid sentences
 are therefore also called \emph{logical truths}---they are true, i.e.,
 satisfied, in any !!{structure} and hence their truth depends only on the
 logical symbols occurring in them and their syntactic !!{structure}, but not
-on the non-logical symbols or their interpretation.  
+on the non-logical symbols or their interpretation.
 \end{explain}
 
 \begin{defn}[Validity]

--- a/first-order-logic/syntax-and-semantics/structures.tex
+++ b/first-order-logic/syntax-and-semantics/structures.tex
@@ -29,7 +29,7 @@ validity, satisfiablity. They are variously called ``structures,''
 \Article{structure} \emph{!!{structure}}~$\Struct M$, for a language
 $\Lang{L}$ of first-order logic consists of the following elements:
 \begin{enumerate}
-\item \emph{Domain:} a non-empty set, $\Domain M$ 
+\item \emph{Domain:} a non-empty set, $\Domain M$
 \item \emph{Interpretation of !!{constant}s:} for each !!{constant}~$c$ of
   $\Lang{L}$, !!a{element} $\Assign{c}{M} \in \Domain M$
 \item \emph{Interpretation of !!{predicate}s:} for each $n$-place
@@ -69,7 +69,7 @@ L_A$. For instance, we might take as the domain the set~$\Int$ of
 integers instead of~$\Nat$, and define the interpretations of $\Obj
 0$, $\Obj \prime$, $\Obj +$, $\Obj \times$, $\Obj <$ accordingly.  But
 we can also define structures for~$\Lang L_A$ which have nothing even
-remotely to do with numbers. 
+remotely to do with numbers.
 \end{ex}
 
 \begin{ex}
@@ -130,13 +130,13 @@ binary !!{function} $\times$. Hence, the !!{value} of $\Obj{four}$
 is just 4, and the !!{value} of $\times(\Obj{two},
 +(\Obj{three},\Obj{zero}))$ (or in infix notation, $\Obj{two}
 \times (\Obj{three} + \Obj{zero})$ ) is
-\begin{align*} 
+\begin{align*}
 \Value{\times(\Obj{two}, +(\Obj{three},\Obj{zero})}{M}&=
-\Assign{\times}{M}(\Value{\Obj{two}}{M}, \Value{\Obj{two}, 
+\Assign{\times}{M}(\Value{\Obj{two}}{M}, \Value{\Obj{two},
 +(\Obj{three}, \Obj{zero})}{M})\\
-&= \Assign{\times}{M}(\Value{\Obj{two}}{M}, \Assign{+}{M}(\Value{\Obj{three}}{M}, 
+&= \Assign{\times}{M}(\Value{\Obj{two}}{M}, \Assign{+}{M}(\Value{\Obj{three}}{M},
 \Value{\Obj{zero}}{M})) \\
-&= \Assign{\times}{M}(\Assign{\Obj{two}}{M}, \Assign{+}{M}(\Assign{\Obj{three}}{M}, 
+&= \Assign{\times}{M}(\Assign{\Obj{two}}{M}, \Assign{+}{M}(\Assign{\Obj{three}}{M},
 \Assign{\Obj{zero}}{M})) \\
 &= \Assign{\times}{M}(2, \Assign{+}{M}(3, 0)) \\
 &= \Assign{\times}{M}(2, 3) \\

--- a/first-order-logic/syntax-and-semantics/terms-formulas.tex
+++ b/first-order-logic/syntax-and-semantics/terms-formulas.tex
@@ -50,9 +50,9 @@ is defined inductively as follows:
   atomic !!{formula}.
 
 \item If $t_1$ and $t_2$ are terms of~$\Lang L$, then $\Atom{\eq}{t_1, t_2}$
-  is an atomic !!{formula}.  
+  is an atomic !!{formula}.
 
-\tagitem{prvNot}{If $!A$ is a !!{formula}, then $\lnot !A$ is 
+\tagitem{prvNot}{If $!A$ is a !!{formula}, then $\lnot !A$ is
   !!{formula}.}{}
 
 \tagitem{prvAnd}{If $!A$ and $!B$ are !!{formula}s, then $(!A \land
@@ -83,7 +83,7 @@ The definitions of the set of terms and that of !!{formula}s are
 !!{formula}s in infinitely many stages.  In the initial stage, we
 pronounce all atomic formulas to be formulas; this corresponds to the
 first few cases of the definition, i.e., the cases for
-\iftag{prvTrue}{$\ltrue$, }{}% 
+\iftag{prvTrue}{$\ltrue$, }{}%
 \iftag{prvFalse}{$\lfalse$, }{}%
 $\Atom{R}{t_1,\dots,t_n}$ and $\Atom{\eq}{t_1,t_2}$.  ``Atomic !!{formula}''
 thus means any !!{formula} of this form.
@@ -111,13 +111,13 @@ in order for
 \iftag{prvEx}{$\lexists[x][!A]$ }{}%
 \iftag{notprvEx,notprvAll}{}{and }%
 \iftag{prvAll}{$\lforall[x][!A]$ }{}%
-to count as 
+to count as
 \iftag{notprvEx,notprvAll}{a !!{formula}}{!!{formula}s}.
 Nothing bad happens if you don't require this, and it makes things
 easier.
 \end{intro}
 
-\begin<defNot,defOr,defAnd,defIf,defIff,defTrue,defFalse,defEx,defAll>{defn} 
+\begin<defNot,defOr,defAnd,defIf,defIff,defTrue,defFalse,defEx,defAll>{defn}
 Formulas constructed using the defined operators are to be understood
 as follows:
 
@@ -141,7 +141,7 @@ as follows:
   \iftag{prvOr}{$\lnot(\lnot !A \lor \lnot !B)$}{$\lnot (!A \lif
     \lnot !B)$}.}{}
 
-\tagitem{defIf}{$!A \lif !B$ abbreviates 
+\tagitem{defIf}{$!A \lif !B$ abbreviates
   \iftag{prvOr}{$\lnot !A \lor !B)$}{$\lnot (!A \land \lnot !B)$}.}{}
 
 \tagitem{defIff}{$!A \liff !B$ abbreviates $(!A \lif !B) \land (!B

--- a/first-order-logic/syntax-and-semantics/unique-readability.tex
+++ b/first-order-logic/syntax-and-semantics/unique-readability.tex
@@ -36,7 +36,7 @@ $!D \lif !D$ and $!B$ is~$!D$.  Correspondingly, there are two ways to
 ``read'' the !!{formula}~$!D \lif !D \lif !D$. It is of the form $!B
 \lif !C$ where $!B$ is $!D$ and $!C$ is $!D \lif !D$, but \emph{it is
   also} of the form $!B \lif !C$ with $!B$ being $!D \lif !D$ and $!C$
-being~$!D$. 
+being~$!D$.
 
 If this happens, our definitions will not always work. For instance,
 when we define the !!{main operator} of a formula, we say: in a
@@ -175,7 +175,7 @@ or with a quantifier. On the other hand, !!{formula}s that start with
 
 So we really only have to show that if $!A$ is of the form $(!B \ast
 !C)$ and also of the form $(!B' \mathbin{\ast'} !C')$, then $!B \ident
-!B'$, $!C \ident !C'$, and $\ast = {\ast'}$.  
+!B'$, $!C \ident !C'$, and $\ast = {\ast'}$.
 
 So suppose both $!A \ident (!B \ast !C)$ and $!A \ident (!B'
 \mathbin{\ast'} !C')$.  Then either $!B \ident !B'$ or not.  If it is,

--- a/incompleteness/arithmetization-syntax/coding-formulas.tex
+++ b/incompleteness/arithmetization-syntax/coding-formulas.tex
@@ -24,7 +24,7 @@ one of the following holds:
 x = \Gn{\Obj P^n_j(} \concat \fn{flatten}(z) \concat \Gn{)}.
 \]
 \item There are $z_1, z_2 < x$ such that $\fn{Term}(z_1)$,
-  $\fn{Term}(z_2)$, and 
+  $\fn{Term}(z_2)$, and
 \[
 x = z_1 \concat \Gn{\eq} \concat z_2.
 \]
@@ -41,7 +41,7 @@ of !!a{formula} is primitive recursive.
 \begin{proof}
 A sequence of symbols~$s$ is !!a{formula} iff there is formation
 sequence~$s_0$, \dots, $s_{k-1} = s$ of !!{formula} which records
-how~$s$ was formed from atomic !!{formula}s according the the
+how~$s$ was formed from atomic !!{formula}s according to the
 formation rules.  The code for each $s_i$ (and indeed of the code of
 the sequence $\tuple{s_0, \dots, s_{k-1}}$ is less than the code~$x$
 of~$s$.

--- a/incompleteness/arithmetization-syntax/coding-symbols.tex
+++ b/incompleteness/arithmetization-syntax/coding-symbols.tex
@@ -36,9 +36,9 @@ defined as follows:
 \[
 \begin{array}{cccccccccc}
 \lnot & \lor & \land & \lif & \lforall & \lexists & \eq & ( & ) & ,\\
-\tuple{0, 0} & \tuple{0, 1} & \tuple{0, 2} & \tuple{0, 3} & 
+\tuple{0, 0} & \tuple{0, 1} & \tuple{0, 2} & \tuple{0, 3} &
 \tuple{0, 4} & \tuple{0, 5} & \tuple{0, 6} & \tuple{0, 7} &
-\tuple{0, 8} & \tuple{0, 9} 
+\tuple{0, 8} & \tuple{0, 9}
 \end{array}
 \]
 \item If $s$ is the $i$-th variable $\Obj x_i$, then $\scode s = \tuple{1, i}$.

--- a/incompleteness/arithmetization-syntax/coding-terms.tex
+++ b/incompleteness/arithmetization-syntax/coding-terms.tex
@@ -28,7 +28,7 @@ of a term, is primitive recursive.
 \begin{proof}
 A sequence of symbols~$s$ is a term iff there is a sequence~$s_0$,
 \dots, $s_{k-1} = s$ of terms which records how the term~$s$ was formed
-from !!{constant}s and !!{variable}s according the the formation rules
+from !!{constant}s and !!{variable}s according to the formation rules
 for terms. To express that such a putative formation sequence follows
 the formation rules it has to be the case that, for each $i < k$, either
 \begin{enumerate}
@@ -60,7 +60,7 @@ $\fn{flatten}(z)$ turns the sequence $\tuple{\Gn{t_1}, \dots,
 
 The indices $j$, $n$, the G\"odel numbers $z_l$ of the terms $t_l$,
 and the code~$z$ of the sequence~$\tuple{z_1, \dots, z_n}$, in (3) are
-all less than~$y$. We can replace $k$ above with $\len{y}$. Hence we
+all less than~$y$.  We can replace $k$ above with $\len{y}$.  Hence we
 can express ``$y$ is the code of a formation sequence of the term with
 G\"odel number~$x$'' in a way that shows that this relation is
 primitive recursive.
@@ -70,7 +70,7 @@ recursive bound on~$y$.  But if $x$ is the G\"odel number of a term,
 it must have a formation sequence with at most $\len{x}$ terms (since
 every term in the formation sequence of~$s$ must start at some place
 in~$s$, and no two subterms can start at the same place).  The G\"odel
-number of each subterm of $s$ is of course $\le x$. Hence, there
+number of each subterm of $s$ is of course $\le x$.  Hence, there
 always is a formation sequence with code $\le x^{\len{x}}$.
 \end{proof}
 

--- a/incompleteness/arithmetization-syntax/introduction.tex
+++ b/incompleteness/arithmetization-syntax/introduction.tex
@@ -17,7 +17,7 @@ this directly, by considering computable functions and relations on
 symbols, sequences of symbols, and other objects built from them.
 Since the objects of logical syntax are all finite and built from
 !!a{enumerable} sets of symbols, this is possible for some models of
-computation. But other models of computation are restricted to
+computation.  But other models of computation are restricted to
 numbers, their relations and functions.  Moreover, ultimately we also
 want to deal with syntax in certain theories, specifically, in
 theories formulated in the language of arithmetic.  In these cases it

--- a/incompleteness/arithmetization-syntax/proofs-in-lk.tex
+++ b/incompleteness/arithmetization-syntax/proofs-in-lk.tex
@@ -30,23 +30,23 @@ If $\Pi$ is a !!{derivation} in $\Log{LK}$, then $\Gn{\Pi}$ is
   inference.
 
 \begin{tabular}{lccccccc}
-\text{Rule:} & \text{Contr} & $\lnot$ left & $\lnot$ right & 
+\text{Rule:} & \text{Contr} & $\lnot$ left & $\lnot$ right &
    $\land$ left  & $\lor$ right & $\lif$ right \\
 $k$: & 1 & 2 & 3 & 4 & 5 & 6 \\[2ex]
-\text{Rule:} & $\lforall$ left & 
+\text{Rule:} & $\lforall$ left &
    $\lforall$ right & $\lexists$ left & $\lexists$ right & = \\
-$k$: & 7 & 8 & 9 & 10 & 11  
+$k$: & 7 & 8 & 9 & 10 & 11
 \end{tabular}
 \item $\tuple{2, \Gn{\Gamma \Sequent \Delta}, k, \Gn{\Pi'},
   \Gn{\Pi''}}$ if $\Pi$ ends in an inference with two premises, $k$ is
   given by the following table according to which rule was used in the
-  last inference, and $\Pi'$, $\Pi''$ are the the immediate subproof
+  last inference, and $\Pi'$, $\Pi''$ are the immediate subproof
   ending in the left and right premise of the last inference,
   respectively.
 
 \begin{tabular}{lcccc}
 \text{Rule:} & \text{Cut} & $\land$ right & $\lor$ left & $\lif$ left \\
-$k$: & 1 & 2 & 3 & 4 
+$k$: & 1 & 2 & 3 & 4
 \end{tabular}
 \end{enumerate}
 \end{defn}
@@ -72,10 +72,10 @@ are primitive recursive.
 \begin{enumerate}
 \item $!A \in \Gamma$ iff $\Gn{!A}$ occurs in the
   sequence~$\Gn{\Gamma}$, i.e, $\fn{IsIn}(x, g) \defiff \lexists[i <
-    \len{g}][(g)_i = x]$. We'll abbreviate this as $x \in g$.
+    \len{g}][(g)_i = x]$.  We'll abbreviate this as $x \in g$.
 \item $\Gamma \subseteq \Delta$ iff every element of $\Gn{\Gamma}$ is
   also an an element of $\Gn{\Delta}$, i.e., $\fn{SubSet}(g, d)
-  \defiff \lforall[i < \len{g}][(g)_i \in d]$. We'll abbreviate this
+  \defiff \lforall[i < \len{g}][(g)_i \in d]$.  We'll abbreviate this
   as $g \subseteq d$.
 \item $\Gamma \Sequent \Delta$ is an initial sequent if either there
   is a !!{sentence}~$!A$ such that $\Gamma \Sequent \Delta$ is $!A
@@ -84,10 +84,10 @@ are primitive recursive.
   numbers,
 \begin{align*}
 \fn{InitSeq}(s) \defiff &
-\lexists[x < s][(\fn{Sent}(x) \land 
-s = \tuple{\tuple{x},\tuple{x}})] 
+\lexists[x < s][(\fn{Sent}(x) \land
+s = \tuple{\tuple{x},\tuple{x}})]
 \lor {}\\
-& \lexists[t<s][(\fn{Term}(t)  \land 
+& \lexists[t<s][(\fn{Term}(t)  \land
 s = \tuple{0, t\concat \Gn{\eq} \concat t})].
 \end{align*}
 \item Here we have to show that for each rule of inference~$R$ the
@@ -104,11 +104,11 @@ every $!B \in \Delta$, either $!B = \lexists[x][!A]$ or $!B \in
 \Delta'$, and for every $!B \in \Delta'$, $!B = \Subst{!A}{t}{x}$ or
 $!B \in \Delta$.  We just have to translate this into G\"odel numbers.
 If $s = \Gn{\Gamma \Sequent \Delta}$ then $(s)_0 = \Gn{\Gamma}$ and
-$(s)_1 = \Gn{\Delta}$. So:
+$(s)_1 = \Gn{\Delta}$.  So:
 \begin{align*}
-\fn{FollowsBy}_{\lexists \text{right}}(s, s') \defiff {} & 
+\fn{FollowsBy}_{\lexists \text{right}}(s, s') \defiff {} &
 (s)_0 \subseteq (s')_0 \land (s')_0 \subseteq (s)_0 \land {}\\
-& 
+&
 \lexists[f<s][\lexists[x<s][\lexists[t<s'][(\fn{Frm}(f) \land \fn{Var}(x) \land \fn{Term}(t) \land {}]]] \\
 & \fn{Subst}(f,t,x) \in (s')_1 \land \#(\lexists) \concat x \concat f \in (s)_1 \land {}\\
 & \lforall[i < \len{(s)_1}][(((s)_1)_i = \#(\lexists) \concat x \concat f \lor ((s)_1)_i \in (s')_1)] \land {} \\
@@ -120,7 +120,7 @@ with G\"odel number~$f$, a variable with G\"odel number $x$, and a
 term with G\"odel number~$t$,'' ``$\Subst{!A}{t}{x} \in \Delta' \land
 \lexists[x][!A] \in \Delta$,'' ``for all $!B \in \Delta$, either $!B =
 \lexists[x][!A]$ or $!B \in \Delta'$,'' ``for all $!B \in \Delta'$,
-either $!B = \Subst{!A}{t}{x}$ or $!B \in \Delta$. Note that in the
+either $!B = \Subst{!A}{t}{x}$ or $!B \in \Delta$.  Note that in the
 last two lines, we quantify over the elements~$!B$ of~$\Delta$ and
 $\Delta'$ not directly, but via their place~$i$ in the G\"odel numbers
 of $\Delta$ and $\Delta'$. (Remember that $\Gn{\Delta}$ is the number
@@ -147,11 +147,11 @@ of a sequence of G\"odel numbers of !!{formula}s in $\Delta$.)
 & \quad ((s)_2 = 4 \land \fn{FollowsBy}_{\lif\text{left}}((s)_1, ((s)_3)_1), ((s)_4)_1)) \land {}\\
 & \quad \fn{nDeriv}((s)_3, n) \land \fn{nDeriv}((s)_4, n))
 \end{align*}
-This is a primitive recursive definition. If the number~$n$ is large
+This is a primitive recursive definition.  If the number~$n$ is large
 enough, e.g., larger than the maximum number of inferences between an
 initial sequent and the end sequent in~$s$, it holds of $s$ iff $s$ is
 the G\"odel number of a correct !!{derivation}.  The number $s$ itself
-is larger than that maximum number of inferences. So we can now define
+is larger than that maximum number of inferences.  So we can now define
 $\fn{Deriv}(s)$ by $\fn{nDeriv}(s,s)$.
 \end{enumerate}
 \end{proof}
@@ -176,7 +176,7 @@ primitive recursive.
 
 \begin{proof}
 Suppose ``$y \in \Gamma$'' is given by the primitive recursive
-predicate~$R_\Gamma(y)$. We have to show that $\fn{Pr}_\Gamma(x, y)$
+predicate~$R_\Gamma(y)$.  We have to show that $\fn{Pr}_\Gamma(x, y)$
 which holds iff $y$ is the G\"odel number of a sentence~$!A$ and
 $x$~is the code of an $\Log{LK}$-!!{derivation} with end sequent
 $\Gamma_0 \Sequent !A$ is primitive recursive.
@@ -185,7 +185,7 @@ By the previous proposition, the property $\fn{Deriv}()$ which holds
 iff $x$ is the code of a correct derivation~$\Pi$ in $\Log{LK}$ is
 primitive recursive.  If $x$ is such a code, then $(x)_1$ is the code
 of the end sequent of~$\Pi$, and so $((x)_1)_0$ is the code of the
-left side of the end sequent and $((x)_1)_1$ the right side. So we can
+left side of the end sequent and $((x)_1)_1$ the right side.  So we can
 express ``the right side of the end sequent of~$\Pi$ is~$!A$'' as
 $\len{((x)_1)_1} = 1 \land (((x)_1)_1)_0 = x$.  The left side of the
 end sequent of $\Pi$ is of course automatically finite, we just have

--- a/incompleteness/arithmetization-syntax/substitution.tex
+++ b/incompleteness/arithmetization-syntax/substitution.tex
@@ -45,7 +45,7 @@ recursive.
 \begin{prob}
 Show that $\fn{FreeFor}(x, y, z)$, which holds iff the term with
 G\"odel number~$y$ is !!{free for} the variable with G\"odel
-number~$z$ in the the formula with G\"odel number~$x$, is primitive
+number~$z$ in the formula with G\"odel number~$x$, is primitive
 recursive.
 \end{prob}
 

--- a/incompleteness/incompleteness-provability/first-incompleteness-thm.tex
+++ b/incompleteness/incompleteness-provability/first-incompleteness-thm.tex
@@ -43,24 +43,24 @@ $\lexists[x][!A(x)]$ is any sentence and $\Th{T}$ proves $\lnot
 does not prove $\lexists[x][!A(x)]$.
 \end{defn}
 
-We can now prove the following. 
+We can now prove the following.
 \begin{thm}
 \ollabel{thm:first-incompleteness}
 Let $\Th{T}$ be any $\omega$-consistent, computably axiomatized theory
 extending $\Th{Q}$. Then $\Th{T}$ is not complete.
 \end{thm}
 
-\begin{proof} 
+\begin{proof}
 Let $\Th{T}$ be any computably axiomatized theory containing $\Th{Q}$,
 and let $\OProv[T](y)$ be the formula we described above. By the
 fixed-point lemma, there is a formula $!G_\Th{T}$ such that $\Th{T}$ proves
 \begin{equation}
-\ollabel{eqn:qpf} 
+\ollabel{eqn:qpf}
 !G_\Th{T} \liff \lnot \OProv[T](\gn{!G_\Th{T}}).
 \end{equation}
 Note that $!A$ says, in essence, ``I am not provable.''
 
-We claim that 
+We claim that
 \begin{enumerate}
 \item If $\Th{T}$ is consistent, $\Th{T}$ doesn't prove $!G_\Th{T}$
 \item If $\Th{T}$ is $\omega$-consistent, $\Th{T}$ doesn't prove
@@ -91,7 +91,7 @@ of $!G_\Th{T}$ in $\Th{T}$, $\Th{T}$ proves
 \]
 On the other hand, by \olref{eqn:qpf}, $\lnot !G_\Th{T}$
 is equivalent to $\lexists[x][\OPrf[T](x,\gn{!G_\Th{T}})]$. So $\Th{T}$
-is $\omega$-inconsistent. 
+is $\omega$-inconsistent.
 \end{proof}
 
 \end{document}

--- a/incompleteness/representability-in-q/beta-function.tex
+++ b/incompleteness/representability-in-q/beta-function.tex
@@ -71,7 +71,7 @@ A couple of observations will help us in this regard. Given
 $y_0$, \dots,~$y_n$, let
 \[
 j = \max(n,y_0,\dots,y_n)+1,
-\] 
+\]
 and let
 \begin{eqnarray*}
 x_0 & = & 1 + j\fac \\
@@ -114,7 +114,7 @@ We can then show that all of the following are in $C$:
 \begin{enumerate}
 \item The pairing function, $J(x,y) = \frac{1}{2}[(x+y)(x+y+1)] + x$
 % maybe explain more what is going on here, a bit confusing.
-\item Projections 
+\item Projections
 \[
 K(z) = \mu {x \leq q} \; (\lexists[y \leq z] \, [z = J(x,y)])
 \]
@@ -137,11 +137,11 @@ Now define
 \[
 \beta^*(d_0,d_1,i) = \fn{rem}(1+(i+1) d_1,d_0)
 \]
-and 
+and
 \[
 \beta(d,i) = \beta^*(K(d),L(d),i).
 \]
-This is the function we need. Given $a_0,\dots,a_n$, as above, let 
+This is the function we need. Given $a_0,\dots,a_n$, as above, let
 \[
 j = \max(n,a_0,\dots,a_n)+1,
 \]
@@ -152,7 +152,7 @@ value $d_0$ such that for each $i$,
 \[
 d_0 \equiv a_i \mod (1+(i+1)d_1)
 \]
-and so (because $d_1$ is greater than $a_i$), 
+and so (because $d_1$ is greater than $a_i$),
 \[
 a_i = \fn{rem}(1+(i+1)d_1,d_0).
 \]

--- a/incompleteness/representability-in-q/c-representable.tex
+++ b/incompleteness/representability-in-q/c-representable.tex
@@ -10,7 +10,7 @@
 \olsection{Functions in $C$ are Representable in $\Th{Q}$}
 
 We have to show that every function in $C$ is representable in
-$\Th{Q}$.  In the end, we need to show how to assign to each $k$-ary
+$\Th{Q}$. In the end, we need to show how to assign to each $k$-ary
 function $f(x_0,\dots,x_{k-1})$ in $C$ a formula
 $!A_f(x_0,\dots,x_{k-1},y)$ that represents it.
 
@@ -31,14 +31,14 @@ $\lforall[x][\eq/[0][x']]$. By a quantifier axiom, replacing $x$ by
 
 In the induction step, we can assume the claim is true for $n$, and
 consider $n+1$. Let $m$ be any natural number. There are two
-possibilities: either $m = 0$ or for some $k$ we have $m = k+1$.  The
+possibilities: either $m = 0$ or for some $k$ we have $m = k+1$. The
 first case is handled as above. In the second case, suppose $n+1 \neq
 k+1$. Then $n \neq k$. By the induction hypothesis for $n$ we have
 $\Th{Q} \Proves \eq/[\num n][\num k]$. We have an axiom that says
 $\lforall[x][\lforall[y][\eq[x'][y'] \lif \eq[x][y]]]$. Using a
 quantifier axiom, we have $\eq[\num n'][\num k'] \lif \eq[\num n][\num
   k]$. Using propositional logic, we can conclude, in $\Th{Q}$,
-$\eq/[\num n][\num k] \lif \eq/[\num n'][\num k']$.  Using modus
+$\eq/[\num n][\num k] \lif \eq/[\num n'][\num k']$. Using modus
 ponens, we can conclude $\eq/[\num n'][\num k']$, which is what we want,
 since $\num k'$ is $\num m$.
 \end{proof}
@@ -109,7 +109,7 @@ It can be shown that this works using some additional lemmas, e.g.,
 \end{lem}
 
 It is again worth mentioning that this is weaker than saying that $\Th{Q}$
-proves $\lforall[x][\lforall[y][(x' + y) = (x +y)']]$ (which is false). 
+proves $\lforall[x][\lforall[y][(x' + y) = (x +y)']]$ (which is false).
 
 \begin{proof}
 The proof is, as usual, by induction on $n$. In the base case, $n =
@@ -140,7 +140,7 @@ x < \num {n+1} \lif (\eq[x][\num 0] \lor \dots \lor \eq[x][\num n]).
 \end{enumerate}
 \end{lem}
 
-\begin{proof} 
+\begin{proof}
 Let us do 1 and part of 2, informally (i.e., only giving hints as to
 how to construct the formal derivation).
 

--- a/incompleteness/representability-in-q/c.tex
+++ b/incompleteness/representability-in-q/c.tex
@@ -15,20 +15,20 @@ Let $C$ be the smallest set of functions containing
 \item successor,
 \item addition,
 \item multiplication,
-\item projections, and 
+\item projections, and
 \item the characteristic function for equality, $\Char{=}$;
 \end{enumerate}
 and closed under
 \begin{enumerate}
 \item composition, and
 \item unbounded search, applied to regular
-functions. 
+functions.
 \end{enumerate}
 Remember this last restriction means simply that you can only use the
 $\mu$ operation when the result is total. Compare this to the
 definition of the \emph{general recursive} functions: here we have
 added plus, times, and $\Char{=}$, but we have dropped primitive
-recursion.  
+recursion.
 
 Clearly everything in $C$ is recursive, since plus, times,
 and $\Char{=}$ are. We will show that the converse is also true; this

--- a/incompleteness/representability-in-q/introduction.tex
+++ b/incompleteness/representability-in-q/introduction.tex
@@ -41,7 +41,7 @@ term $0^{''\ldots'}$ where there are $n$ tick marks in all.
 
 As a theory of arithmetic, $Q$ is \emph{extremely} weak; for example,
 you can't even prove very simple facts like $\lforall[x][\eq/[x][x']]$
-or $\lforall[x][\lforall[y][(x+ y) = (y+x)]]$.  But we will see that
+or $\lforall[x][\lforall[y][(x+ y) = (y+x)]]$. But we will see that
 much of the reason that $Q$ is so interesting is \emph{because} it is
 so weak, in fact, just barely strong enough for the incompleteness
 theorem to hold; and also because it has a \emph{finite} set of
@@ -53,7 +53,7 @@ is obtained by adding a schema of induction to~$\Th{Q}$:
 (!A(0) \land \lforall[x][(!A(x) \lif !A(x'))]) \lif \lforall[x][!A(x)]
 \]
 where $!A(x)$ is any formula, possibly with free variables other than
-$x$.  Using induction, one can do much better; in fact, it takes a
+$x$. Using induction, one can do much better; in fact, it takes a
 good deal of work to find ``natural'' statements about the natural
 numbers that can't be proved in Peano arithmetic!
 

--- a/incompleteness/representability-in-q/prim-rec.tex
+++ b/incompleteness/representability-in-q/prim-rec.tex
@@ -35,6 +35,6 @@ But then we have
 \[
 h(x,\vec z) = \beta(\hat h(x,\vec z),x),
 \]
-so $h$ is in $C$ as well. 
+so $h$ is in $C$ as well.
 
 \end{document}

--- a/incompleteness/representability-in-q/representable-comp.tex
+++ b/incompleteness/representability-in-q/representable-comp.tex
@@ -30,7 +30,7 @@ f(n_0,\dots,n_{k}) = (\mu s (\mbox{``$(s)_0$ is a proof of $!A(\bar
   n_0,\dots,\bar n_{k},\bar{(s)_1})$ in $\Th{Q}$''}))_1.
 \]
 This completes the proof, modulo the (involved but routine) details of
-coding and defining the function and relation above.  
+coding and defining the function and relation above.
 \end{proof}
 
 \end{document}

--- a/incompleteness/representability-in-q/representing-relations.tex
+++ b/incompleteness/representability-in-q/representing-relations.tex
@@ -43,7 +43,7 @@ $!A_R(x_0,\dots,x_k)$ be the formula $!A_{\chi_R}(x_0,\dots,x_k,\num
 $\chi_R(n_0,\dots,n_k) = 1$, in which case $\Th{Q}$ proves
 $!A_{\chi_R}(\num n_0,\dots,\num n_k,\num 1)$, and so $\Th{Q}$ proves
 $!A_R(\num n_0,\dots,\num n_k)$. On the other hand if
-$R(n_0,\dots,n_k)$ is false, then $\chi_R(n_0,\dots,n_k) = 0$.  This
+$R(n_0,\dots,n_k)$ is false, then $\chi_R(n_0,\dots,n_k) = 0$. This
 means that $\Th{Q}$ proves $!A_{\chi_R}(\num n_0,\dots,\num n_k,y)
 \lif y = \num 0$. Since $\Th{Q}$ proves $\lnot (\num 0 = \num 1)$,
 $\Th{Q}$ proves $\lnot !A_{\chi_R}(\num n_0,\dots,\num n_k,\num 1)$,

--- a/incompleteness/representability-in-q/undecidability.tex
+++ b/incompleteness/representability-in-q/undecidability.tex
@@ -18,10 +18,10 @@ which decides, given a sentence~$!A$ in the language of arithmetic,
 whether $\Th{Q} \Proves !A$ or not.  We can make this more precise by
 asking: Is the relation~$\fn{Prov}_{\Th{Q}}(y)$, which holds of~$y$
 iff $y$ is the G\"odel number of a sentence provable in~$\Th{Q}$,
-recursive?  The answer is: no. 
+recursive?  The answer is: no.
 
 \begin{thm}
-$\Th{Q}$ is undecidable, i.e., the relation 
+$\Th{Q}$ is undecidable, i.e., the relation
 \[
 \fn{Prov}_{\Th{Q}}(y) \defiff \fn{Sent}(y) \land
 \lexists[x][\fn{Pr}_{\Th{Q}}(x, y)]
@@ -33,13 +33,13 @@ is not recursive.
 Suppose it were.  Then we could solve the halting problem as follows:
 Given $e$ and $n$, we know that $\cfind{e}(n) \defined$ iff there is
 an~$s$ such that $T(e, n, s)$, where $T$ is Kleene's predicate from
-\olref[cmp][rec][nft]{thm:kleene-nf}. Since $T$ is primitive recursive
+\olref[cmp][rec][nft]{thm:kleene-nf}.  Since $T$ is primitive recursive
 it is representable in~$\Th{Q}$ by a formula $!B_T$, that is, $\Th{Q}
 \Proves !B_T(\num{e}, \num{n}, \num{s})$ iff $T(e, n, s)$.  If $\Th{Q}
 \Proves !B_T(\num{e}, \num{n}, \num{s})$ then also $ \Th{Q} \Proves
-\lexists[y][!B_T(\num{e}, \num{n}, y)]$. If no such $s$ exists, then
+\lexists[y][!B_T(\num{e}, \num{n}, y)]$.  If no such $s$ exists, then
 $\Th{Q} \Proves \lnot !B_T(\num{e}, \num{n}, \num{s})$ for
-every~$s$. But $\Th{Q}$ is $\omega$-consistent, i.e., if $\Th{Q}
+every~$s$.  But $\Th{Q}$ is $\omega$-consistent, i.e., if $\Th{Q}
 \Proves \lnot !A(\num{n})$ for every~$n \in \Nat$, then $\Th{Q}
 \Proves/ \lexists[y][!A(y)]$.  We know this because the axioms of
 $\Th{Q}$ are true in the standard model~$\Struct{N}$.  So, $\Th{Q}
@@ -48,9 +48,9 @@ $\Th{Q} \Proves \lexists[y][!B_T(\num{e}, \num{n}, y)]$ iff there is
 an $s$ such that $T(e, n, s)$, i.e., iff $\cfind{e}(n) \defined$.
 From $e$ and~$n$ we can compute $\Gn{\lexists[y][!B_T(\num{e},
     \num{n}, y)]}$, let $g(e, n)$ be the primitive recursive function
-which does that. So
+which does that.  So
 \[
-h(e, n) = 
+h(e, n) =
 \begin{cases}
 1 & \text{if $\fn{Pr}_{\Th{Q}}(g(e, n))$}\\
 0 & \text{otherwise}.

--- a/incompleteness/theories-computability/complete-decidable.tex
+++ b/incompleteness/theories-computability/complete-decidable.tex
@@ -32,7 +32,7 @@ of $!A$.
 Put in different terms, we already know that $\Th{T}$ is c.e.; so by a
 theorem we proved before, it suffices to show that the complement of
 $\Th{T}$ is c.e. But a formula $!A$ is in $\num T$ if and only if $\lnot
-!A$ is in $\Th{T}$; so $\num T \leq_m T$. 
+!A$ is in $\Th{T}$; so $\num T \leq_m T$.
 \end{proof}
 
 \end{document}

--- a/incompleteness/theories-computability/consis-with-q.tex
+++ b/incompleteness/theories-computability/consis-with-q.tex
@@ -42,7 +42,7 @@ is not in $C$.
 
 We've shown that if $!A$ is in $\Th{Q}$, then it is in $C$, and if $!A$
 is in $Q'$, then it is in $\num C$. So $C$ is a computable separation,
-which is the contradiction we were looking for. 
+which is the contradiction we were looking for.
 \end{proof}
 
 This theorem is very powerful. For example, it implies:
@@ -55,7 +55,7 @@ This theorem is very powerful. For example, it implies:
 
 \begin{proof}
 First-order logic is the set of consequences of $\emptyset$,
-which is consistent with $\Th{Q}$. 
+which is consistent with $\Th{Q}$.
 \end{proof}
 
 \end{document}

--- a/incompleteness/theories-computability/extensions-of-q-not-decidable.tex
+++ b/incompleteness/theories-computability/extensions-of-q-not-decidable.tex
@@ -34,7 +34,7 @@ Suppose $R(x,y)$ is a universal computable relation. Let $S(y)$
 be the relation $\lnot R(y,y)$. Since $S(y)$ is computable, for some
 $k$, $S(y)$ is equivalent to $R(k,y)$. But then we have that $S(k)$ is
 equivalent to both $R(k,k)$ and $\lnot R(k,k)$, which is a
-contradiction. 
+contradiction.
 \end{proof}
 
 
@@ -49,7 +49,7 @@ Suppose $\Th{T}$ is a consistent, decidable
 extension of $\Th{Q}$. We will obtain a contradiction by using $\Th{T}$ to
 define a universal computable relation.
 
-Let $R(x,y)$ hold if and only if 
+Let $R(x,y)$ hold if and only if
 \begin{quote}
 $x$ codes a formula $!D(u)$, and $\Th{T}$ proves $!D(\num y)$.
 \end{quote}
@@ -70,7 +70,7 @@ and
 \end{eqnarray*}
 That is, for every $y$, $S(y)$ is true if and only if
 $R(\#(!D_S(u)),y)$ is. So $R$ is universal, and we have the
-contradiction we were looking for. 
+contradiction we were looking for.
 \end{proof}
 
 Let ``true arithmetic'' be the theory $\Setabs{!A}{ \Sat{\Nat}{!A}}$,

--- a/open-logic-about.tex
+++ b/open-logic-about.tex
@@ -2,24 +2,24 @@
 
 The \textit{Open Logic Text} is an open-source, collaborative textbook
 of formal meta-logic and formal methods, starting at an intermediate level
-(i.e., after an introductory formal logic course). It is aimed at a
+(i.e., after an introductory formal logic course). Though aimed at a
 non-mathematical audience (in particular, students of philosophy and
-computer science), but is completely rigorous.
+computer science), it is rigorous.
 
-The \textit{Open Logic Text} is a collaborative project, and is under
-active development.  Coverage of some topics currently included may
+The \textit{Open Logic Text} is a collaborative project and is under
+active development. Coverage of some topics currently included may
 not yet be complete, and many sections still require substantial
-revisions. We plan to expand the text to cover additional topics in
+revision. We plan to expand the text to cover more topics in
 the future. We also plan to add features to the text, such as a
-glossary, further reading, historical notes, pictures, better
+glossary, a list of further reading, historical notes, pictures, better
 explanations, sections explaining the relevance of results to
 philosophy, computer science, and mathematics, and more problems and
-examples.  If you find an error or have a suggestion,
+examples. If you find an error, or have a suggestion,
 \href{https://github.com/OpenLogicProject/OpenLogic/wiki/Contributing}{please
   let the project team know}.
 
 The project operates in the spirit of open source. Not only is the
-texts available for free, we provide it in source LaTeX format under a
+text freely available, we provide the LaTeX source under the
 Creative Commons Attribution license, which gives anyone the right to
 download, use, modify, re-arrange, convert, and re-distribute our
 work, as long as they give appropriate credit.

--- a/sets-functions-relations/functions/function-basics.tex
+++ b/sets-functions-relations/functions/function-basics.tex
@@ -81,9 +81,9 @@ as we know, sets are independent of how they are specified.
 
 \begin{ex}
 We can also define functions by cases. For instance, we could define
-$f \colon \Nat \to \Nat$  by 
+$f \colon \Nat \to \Nat$  by
 \[
-f(x) = 
+f(x) =
 \begin{cases}
   \frac{x}{2} & \text{if $x$ is even} \\
   \frac{x+1}{2} & \text{if $x$ is odd.}

--- a/sets-functions-relations/functions/function-kinds.tex
+++ b/sets-functions-relations/functions/function-kinds.tex
@@ -35,16 +35,16 @@ any element $y$ of the codomain, if $f(x)=y$ and $f(w)=y$, then $x=w$.
 
 A function which is neither !!{injective}, nor !!{surjective}, is the
 constant function $f\colon \Nat \rightarrow \Nat$ where $f(x) = 1$.
-    
+
 A function which is both !!{injective} and !!{surjective} is the
 identity function $f\colon \Nat \rightarrow \Nat$ where $f(x) = x$.
 
 The successor function $f \colon \Nat \rightarrow \Nat$ where $f(x) =
 x+1$ is !!{injective}, but not !!{surjective}.
 
-The function 
+The function
 \[
-f(x) = 
+f(x) =
 \begin{cases}
   \frac{x}{2} & \text{if $x$ is even} \\
   \frac{x+1}{2} & \text{if $x$ is odd.}

--- a/sets-functions-relations/functions/functions.tex
+++ b/sets-functions-relations/functions/functions.tex
@@ -12,7 +12,7 @@
 \olimport{function-kinds}
 
 \olimport{function-operations}
-    
+
 \olimport{isomorphic-functions}
 
 \olimport{partial-functions}

--- a/sets-functions-relations/functions/partial-functions.tex
+++ b/sets-functions-relations/functions/partial-functions.tex
@@ -13,7 +13,7 @@
 
 It is sometimes useful to relax the definition of function so that it
 is not required that the output of the function is defined for all
-possible inputs.  Such mappings are called \emph{partial functions}.
+possible inputs. Such mappings are called \emph{partial functions}.
 
 \begin{defn}
 A \emph{partial function} $f \colon X \pto Y$ is a mapping which

--- a/sets-functions-relations/inductive-defs-proofs/introduction.tex
+++ b/sets-functions-relations/inductive-defs-proofs/introduction.tex
@@ -11,16 +11,16 @@
 \olsection{Introduction}
 
 \begin{explain}
-Induction is a commonly-used proof technique of mathematics in logic. 
-You may be familiar with it from math, in which you do induction on 
-natural numbers. As it turns out, there are lots of different kinds of 
+Induction is a commonly-used proof technique of mathematics in logic.
+You may be familiar with it from math, in which you do induction on
+natural numbers. As it turns out, there are lots of different kinds of
 mathematical and logical sets of objects that lend themselves to induction.
 
-In general, what induction allows one to do is prove a universal claim; that 
-is, show that every object of a certain kind has some property. In particular, 
-induction is often useful where a ``universal introduction'' method of proof 
-is too complicated. Induction only works on matehmatical objects that are 
-constructed in special ways: if every element in the set is either basic or is 
+In general, what induction allows one to do is prove a universal claim; that
+is, show that every object of a certain kind has some property. In particular,
+induction is often useful where a ``universal introduction'' method of proof
+is too complicated. Induction only works on matehmatical objects that are
+constructed in special ways: if every element in the set is either basic or is
 built up from basic elements, then we can use induction on it. More precisely:
 \end{explain}
 
@@ -75,7 +75,7 @@ by using the assumption that $P(k)$.
 
 \begin{align*}
 0 + 1 + \ldots + k &= \frac{k(k+1)}{2} \tag{Assumption} \\
-0 + 1 + \ldots + k + (k+1) &= \frac{k(k+1)}{2} + (k+1) 
+0 + 1 + \ldots + k + (k+1) &= \frac{k(k+1)}{2} + (k+1)
 \tag{Add $k+1$ to both sides} \\
 &= \frac{k(k+1) + 2(k+1)}{2} \\
 &= \frac{2k + k + 2k +2}{2} \\
@@ -117,9 +117,9 @@ which have the property $P$.
 
 Case $\lnot$: [\ldots] Therefore, $\lnot !!^a$ has property $P$.
 
-Case $\land$: [\ldots] Therefore, $!!^a \land !B$ has property $P$. 
+Case $\land$: [\ldots] Therefore, $!!^a \land !B$ has property $P$.
 
-Case $\lor$: [\ldots] Therefore, $!!^a \lor !B$ has property $P$. 
+Case $\lor$: [\ldots] Therefore, $!!^a \lor !B$ has property $P$.
 
 Case $\lif$: [\ldots] Therefore, $!!^a \lif !B$ has property $P$.
 

--- a/sets-functions-relations/relations/operations.tex
+++ b/sets-functions-relations/relations/operations.tex
@@ -17,7 +17,7 @@ considered as sets of pairs). Here are some other ways:
 \begin{enumerate}
 \item The \emph{inverse}~$R^{-1}$ of $R$ is $R^{-1} = \Setabs{\tuple{y,
     x}}{\tuple{x, y} \in R}$.
-\item The \emph{relative product}~$R \mid S$ of $R$ and $S$ is 
+\item The \emph{relative product}~$R \mid S$ of $R$ and $S$ is
 \[
 (R \mid S) = \{\tuple{x, z} : \text{for some } y, Rxy \text{ and } Syz\}
 \]
@@ -58,7 +58,7 @@ I_X$.
 \begin{ex}
 Take the successor relation $S \subseteq \Int^2$. $S^2xy$ iff $x + 2 =
 y$, $S^3xy$ iff $x + 3 = y$, etc. So $R^*xy$ iff for some $i \ge 1$,
-$x + i = y$.  In other words, $S^+xy$ iff $x < y$ (and $R^*xy$ iff $x
+$x + i = y$. In other words, $S^+xy$ iff $x < y$ (and $R^*xy$ iff $x
 \le y$).
 \end{ex}
 

--- a/sets-functions-relations/relations/orders.tex
+++ b/sets-functions-relations/relations/orders.tex
@@ -31,7 +31,7 @@ preorder, even a linear preorder, but not a partial order.
 The relation of \emph{divisibility without remainder} gives us an
 example of a partial order which isn't a linear order: for integers
 $n$, $m$, we say $n$ (evenly) divides $m$, in symbols: $n\mid m$, if
-there is some $k$ so that $m=kn$.  On $\Nat$, this is a partial order,
+there is some $k$ so that $m=kn$. On $\Nat$, this is a partial order,
 but not a linear order: for instance, $2\nmid3$ and also
 $3\nmid2$. Considered as a relation on $\Int$, divisibility is only a
 preorder since anti-symmetry fails: $1\mid-1$ and $-1\mid1$ but

--- a/sets-functions-relations/relations/relations-as-sets.tex
+++ b/sets-functions-relations/relations/relations-as-sets.tex
@@ -21,7 +21,7 @@ encounter, and even more possible relations. Before we review them,
 we'll just point out that we can look at relations as a special sort
 of set. For this, first recall what a \emph{pair} is: if $a$ and $b$
 are two objects, we can combine them into the \emph{ordered
-  pair}~$\tuple{a, b}$.  Note that for ordered pairs the order
+  pair}~$\tuple{a, b}$. Note that for ordered pairs the order
 \emph{does} matter, e.g, $\tuple{a, b} \neq \tuple{b, a}$, in contrast
 to unordered pairs, i.e., 2-element sets, where $\{a, b\}=\{b, a\}$.
 
@@ -61,14 +61,14 @@ pairs of natural numbers can be listed in a 2-dimensional matrix like
 this:
 \[
 \begin{array}{ccccc}
-\mathbf{\tuple{ 0,0 }} & \tuple{ 0,1 } & 
-  \tuple{ 0,2 } & \tuple{ 0,3 } & \ldots\\ 
-\tuple{ 1,0 } & \mathbf{\tuple{ 1,1 }} & 
-  \tuple{ 1,2 } & \tuple{ 1,3 } & \ldots\\ 
-\tuple{ 2,0 } & \tuple{ 2,1 } & 
-  \mathbf{\tuple{ 2,2 }} & \tuple{ 2,3 } & \ldots\\ 
+\mathbf{\tuple{ 0,0 }} & \tuple{ 0,1 } &
+  \tuple{ 0,2 } & \tuple{ 0,3 } & \ldots\\
+\tuple{ 1,0 } & \mathbf{\tuple{ 1,1 }} &
+  \tuple{ 1,2 } & \tuple{ 1,3 } & \ldots\\
+\tuple{ 2,0 } & \tuple{ 2,1 } &
+  \mathbf{\tuple{ 2,2 }} & \tuple{ 2,3 } & \ldots\\
 \tuple{ 3,0 } & \tuple{ 3,1 } & \tuple{ 3,2 } &
-  \mathbf{\tuple{ 3,3 }} & \ldots\\ 
+  \mathbf{\tuple{ 3,3 }} & \ldots\\
 \vdots & \vdots & \vdots & \vdots & \mathbf{\ddots}
 \end{array}
 \]

--- a/sets-functions-relations/relations/special-properties.tex
+++ b/sets-functions-relations/relations/special-properties.tex
@@ -31,7 +31,7 @@ and $Ryz$, then also $Rxz$.
 \end{defn}
 
 \begin{defn}
-A relation~$R \subseteq X^2$ is \emph{symmetric} iff, whenever 
+A relation~$R \subseteq X^2$ is \emph{symmetric} iff, whenever
 $Rxy$, then also~$Ryx$.
 \end{defn}
 
@@ -43,12 +43,12 @@ either $\lnot Rxy$ or $\lnot Ryx$).
 
 \begin{explain}
 In a symmetric relation, $Rxy$ and $Ryx$ always hold together, or
-neither holds. In an anti-symmetric relation, the only way for $Rxy$
+neither holds.  In an anti-symmetric relation, the only way for $Rxy$
 and $Ryx$ to hold together is if $x = y$.  Note that this does not
 \emph{require} that $Rxy$ and $Ryx$ holds when $x = y$, only that it
 isn't ruled out.  So an anti-symmetric relation can be reflexive, but
 it is not the case that every anti-symmetric relation is
-reflexive. Also note that being anti-symmetric and merely not being
+reflexive.  Also note that being anti-symmetric and merely not being
 symmetric are different conditions.  In fact, a relation can be both
 symmetric and anti-symmetric at the same time (e.g., the identity
 relation is).

--- a/sets-functions-relations/sets/basics.tex
+++ b/sets-functions-relations/sets/basics.tex
@@ -13,8 +13,8 @@
 \begin{explain}
 Sets are the most fundamental building blocks of mathematical
 objects. In fact, almost every mathematical object can be seen as a
-set of some kind.  In logic, as in other parts of mathematics, sets
-and set theoretical talk is ubiquitous.  So it will be important to
+set of some kind. In logic, as in other parts of mathematics, sets
+and set theoretical talk is ubiquitous. So it will be important to
 discuss what sets are, and introduce the notations necessary to talk
 about sets and operations on sets in a standard way.
 \end{explain}
@@ -34,14 +34,14 @@ a set. The set of Richard's siblings, for instance, is a set that
 contains one person, and we could write it as $S=\{\textrm{Ruth}\}$.
 In general, when we have some objects $a_{1}$, \dots, $a_{n}$, then
 the set consisting of exactly those objects is written $\{
-a_{1}, \dots, a_{n}\}$.  Frequently we'll specify a set by some
+a_{1}, \dots, a_{n}\}$. Frequently we'll specify a set by some
 property that its elements share---as we just did, for instance, by
 specifying $S$ as the set of Richard's siblings. We'll use the
 following shorthand notation for that: $\Setabs{x}{\ldots x\ldots}$,
 where the $\ldots x\ldots$ stands for the property that $x$ has to
 have in order to be counted among the elements of the set. In our
 example, we could have specified $S$ also as $S = \Setabs{x}{x \text{ is
-a sibling of Richard}}$. 
+a sibling of Richard}}$.
 \end{ex}
 
 \begin{explain}

--- a/sets-functions-relations/sets/pairs-and-products.tex
+++ b/sets-functions-relations/sets/pairs-and-products.tex
@@ -16,7 +16,7 @@ unordered collection. So if we want to represent order, we use
 \emph{ordered $n$-tuples} $\tuple{x_1, \dots, x_n}$.
 \end{explain}
 
-\begin{defn} 
+\begin{defn}
 Given sets $X$ and $Y$, their \emph{Cartesian product} $X \times Y$ is
 $\Setabs{\tuple{x, y}}{x \in X \text{ and } y \in Y}$.
 \end{defn}

--- a/sets-functions-relations/sets/proofs-about-sets.tex
+++ b/sets-functions-relations/sets/proofs-about-sets.tex
@@ -12,23 +12,23 @@
 \begin{explain}
 Sets and the notations we've introduced so far provide us with
 convenient shorthands for specifying sets and expressing relationships
-between them. Often it will also be necessary to prove claims about
+between them.  Often it will also be necessary to prove claims about
 such relationships.  If you're not familiar with mathematical proofs,
-this may be new to you. So we'll walk through a simple example.  We'll
+this may be new to you.  So we'll walk through a simple example.  We'll
 prove that for any sets $X$ and $Y$, it's always the case that $X \cap
 (X \cup Y) = X$.  How do you prove an identity between sets like this?
 Recall that sets are determined solely by their !!{element}s, i.e.,
 sets are identical iff they have the same !!{element}s.  So in this
 case we have to prove that (a) every !!{element} of $X \cap (X \cup
 Y)$ is also an !!{element} of $X$ and, conversely, that (b) every
-!!{element} of $X$ is also an !!{element} of $X \cap (X \cup Y)$. In
+!!{element} of $X$ is also an !!{element} of $X \cap (X \cup Y)$.  In
 other words, we show that both (a) $X \cap (X \cup Y) \subseteq X$ and
 (b) $X \subseteq X \cap (X \cup Y)$.
 
 A proof of a general claim like ``every !!{element}~$z$ of $X \cap (X
 \cup Y)$ is also an !!{element} of $X$'' is proved by first assuming
 that an arbitrary $z \in X \cap (X \cup Y)$ is given, and proving from
-this assumtion that $z \in X$. You may know this pattern as ``general
+this assumtion that $z \in X$.  You may know this pattern as ``general
 conditional proof.''  In this proof we'll also have to make use of the
 definitions involved in the assumption and conclusion, e.g., in this
 case of ``$\cap$'' and ``$\cup$.''  So case (a) would be argued as
@@ -40,15 +40,15 @@ by definition of $\subseteq$, that if $z \in X \cap (X \cup Y)$ then
 $z \in X$, for any~$z$.  So assume that $z \in X \cap (X \cup
 Y)$. Since $z$ is an !!{element} of the intersection of two sets iff
 it is an !!{element} of both sets, we can conclude that $z \in X$ and
-also $z \in X \cup Y$.  In particular, $z \in X$. But this is what
+also $z \in X \cup Y$.  In particular, $z \in X$.  But this is what
 we wanted to show.
 \end{quote}
 
 This completes the first half of the proof.  Note that in the last
 step we used the fact that if a conjunction ($z \in X$ and $z \in X
 \cup Y$) follows from an assumption, each conjunct follows from that
-same assumption. You may know this rule as ``conjunction
-elimination,'' or $\land$Elim. Now let's prove (b):
+same assumption.  You may know this rule as ``conjunction
+elimination,'' or $\land$Elim.  Now let's prove (b):
 
 \begin{quote}
 (b) We now prove that $X \subseteq X \cap (X \cup Y)$, i.e., by
@@ -79,16 +79,16 @@ X \cap (X \cup Y) = X
 \end{prop}
 
 \begin{proof}
-(a) Suppose $z \in X \cap (X \cup Y)$. Then $z \in X$, so $X \cap (X
+(a) Suppose $z \in X \cap (X \cup Y)$.  Then $z \in X$, so $X \cap (X
   \cup Y) \subseteq X$.
 
 (b) Now suppose $z \in X$.  Then also $z \in X \cup Y$, and therefore
-  also $z \in X \cap (X \cup Y)$. Thus, $X \subseteq X \cap (X \cup
+  also $z \in X \cap (X \cup Y)$.  Thus, $X \subseteq X \cap (X \cup
   Y)$.
 \end{proof}
 
 \begin{prob}
-Prove in detail that $X \cup (X \cap Y) = X$. Then compress it into a
+Prove in detail that $X \cup (X \cap Y) = X$.  Then compress it into a
 ``textbook proof.'' (Hint: for the $X \cup (X \cap Y) \subseteq X$
 direction you will need proof by cases, aka $\lor$Elim.)
 \end{prob}

--- a/sets-functions-relations/sets/subsets.tex
+++ b/sets-functions-relations/sets/subsets.tex
@@ -11,7 +11,7 @@
 
 \begin{explain}
 Sets are made up of their elements, and every element of a set is a
-part of that set.  But there is also a sense that some of the elements
+part of that set. But there is also a sense that some of the elements
 of a set \emph{taken together} are a ``part of'' that set. For
 instance, the number~$2$ is part of the set of integers, but the set
 of even numbers is also a part of the set of integers. It's important
@@ -27,7 +27,7 @@ If every element of a set $X$ is also an element of
 \begin{ex}
 First of all, every set is a subset of itself, and $\emptyset$ is a
 subset of every set. The set of even numbers is a subset of the set of
-natural numbers.  Also, $\{ a, b \} \subseteq \{ a, b, c \}$.
+natural numbers. Also, $\{ a, b \} \subseteq \{ a, b, c \}$.
 
 But $\{ a, b, e \}$ is not a subset of $\{ a, b, c \}$.
 \end{ex}
@@ -48,7 +48,7 @@ The set consisting of all subsets of a set~$X$ is called the
 \begin{ex}
 What are all the possible subsets of $\{ a, b, c \}$? They are:
 $\emptyset$, $\{a \}$, $\{b\}$, $\{c\}$, $\{a, b\}$, $\{a, c\}$, $\{b,
-c\}$, $\{a, b, c\}$.  The set of all these subsets is
+c\}$, $\{a, b, c\}$. The set of all these subsets is
 $\Pow{\{a,b,c\}}$:
 \[
 \Pow{\{ a, b, c \}} = \{\emptyset, \{a \}, \{b\}, \{c\}, \{a, b\},

--- a/sets-functions-relations/sets/unions-and-intersections.tex
+++ b/sets-functions-relations/sets/unions-and-intersections.tex
@@ -9,7 +9,7 @@
 \olfileid{sfr}{set}{uni}
 \olsection{Unions and Intersections}
 
-\begin{defn} 
+\begin{defn}
 The \emph{union} of two sets $X$ and $Y$, written $X \cup Y$, is the
 set of all things which are members of $X$, $Y$, or both.
 \[
@@ -31,7 +31,7 @@ b, c \} \cup \emptyset = \{a, b, c \}$.
 
 \begin{defn}
 The \emph{intersection} of two sets $X$ and $Y$, written $X \cap Y$, is
-the set of all things which are !!{element}s of both $X$ and~$Y$. 
+the set of all things which are !!{element}s of both $X$ and~$Y$.
 \[
 X \cap Y = \Setabs{x}{x \in X \land x\in Y}
 \]
@@ -54,9 +54,9 @@ The intersection of any set with the empty set is empty: $\{a, b, c \}
 \end{ex}
 
 \begin{explain}
-We can obviously also form the union or intersection of more than two
-sets.  An elegant way of dealing with this in general is the
-following: suppose you collect all the sets you want to form the union
+We can also form the union or intersection of more than two
+sets. An elegant way of dealing with this in general is the
+followi))ng: suppose you collect all the sets you want to form the union
 (or intersection) of into a single set. Then we can define the union
 of all our original sets as the set of all objects which belong to at
 least one !!{element} of the set, and the intersection as the set of
@@ -68,7 +68,7 @@ If $C$ is a set of sets, then $\bigcup C$ is the set of !!{element}s of
 !!{element}s of $C$:
 \begin{align*}
 \bigcup C & = \Setabs{x}{x \text{ belongs to an !!{element} of } C},
-\text{ i.e.,}\\ 
+\text{ i.e.,}\\
 \bigcup C & = \Setabs{x}{\text{there is a } y \in C
   \text{ so that } x \in y}
 \end{align*}

--- a/sets-functions-relations/size-of-sets/comparing-size.tex
+++ b/sets-functions-relations/size-of-sets/comparing-size.tex
@@ -17,7 +17,7 @@ also compare the sizes of sets in a precise way. Our definition of
 ``is smaller than (or equinumerous)'' will require, instead of a
 !!{bijection} between the sets, a total !!{injective} function from the first
 set to the second. If such a function exists, the size of the first
-set is less than or equal to the size of the second.  Intuitively, 
+set is less than or equal to the size of the second. Intuitively,
 !!a{injective} function from one set to another guarantees that the range of
 the function has at least as many elements as the domain, since no two
 !!{element}s of the domain map to the same !!{element} of the range.

--- a/sets-functions-relations/size-of-sets/enumerability.tex
+++ b/sets-functions-relations/size-of-sets/enumerability.tex
@@ -48,11 +48,11 @@ A couple of points about enumerations:
 \end{enumerate}
 \end{explain}
 
-The following provides a more formal definition of an 
+The following provides a more formal definition of an
 enumeration:
 
 \begin{defn}
-An \emph{enumeration} of a set $X$ is any !!{surjective} function $f: 
+An \emph{enumeration} of a set $X$ is any !!{surjective} function $f:
 \Nat \rightarrow X$.
 \end{defn}
 
@@ -64,7 +64,7 @@ a set $X$ enumerates~$X$. Such a function determines an enumeration as
 defined informally above. Then an enumeration for $X$ is the list
 $f(0)$, $f(1)$, $f(2)$, \dots. Since $f$ is !!{surjective}, every
 !!{element} of $X$ is guaranteed to be the value of $f(n)$ for some~$n
-\in \Nat$.  Hence, every !!{element} of $X$ appears at some finite
+\in \Nat$. Hence, every !!{element} of $X$ appears at some finite
 place in the list. Since the function may be partial or not !!{injective},
 the list may be gappy or redundant, but that is acceptable (as noted
 above). On the other hand, given a list that enumerates all
@@ -74,7 +74,7 @@ undefined if the list has a gap in the $(n+1)$st spot.
 \end{explain}
 
 \begin{ex}
-A function enumerating the natural numbers ($\Nat$) is 
+A function enumerating the natural numbers ($\Nat$) is
 simply the identity function given by $f(n) = n$.
 \end{ex}
 
@@ -84,8 +84,8 @@ The functions $f\colon \Nat \to \Nat$ and $g \colon \Nat \to \Nat$ given by
 f(n) & = 2n \text{ and}\\
 g(n) & = 2n+1
 \end{align}
-enumerate the even natural numbers and the odd natural numbers, 
-respectively. However, neither function is an enumeration of 
+enumerate the even natural numbers and the odd natural numbers,
+respectively. However, neither function is an enumeration of
 $\Nat$, since neither is !!{surjective}.
 \end{ex}
 
@@ -94,12 +94,12 @@ The function $f(n) = \lceil \frac{(-1)^n n}{2}\rceil$ (where $\lceil x
 \rceil$ denotes the \emph{ceiling} function, which rounds $x$ up to
 the nearest integer) enumerates the set of integers~$\Int$. Notice
 how $f$ generates the values of $\Int$ by ``hopping'' back and forth
-between positive and negative integers: 
+between positive and negative integers:
 \[
 \begin{array}{c c c c c c c}
 f(1) & f(2) & f(3) & f(4) & f(5) & f(6) & \dots \\ \\
-\lceil - \tfrac{1}{2}\rceil & \lceil \tfrac{2}{2} \rceil & \lceil - 
-\tfrac{3}{2} \rceil & \lceil \tfrac{4}{2} \rceil  & \lceil -\tfrac{5}{2} 
+\lceil - \tfrac{1}{2}\rceil & \lceil \tfrac{2}{2} \rceil & \lceil -
+\tfrac{3}{2} \rceil & \lceil \tfrac{4}{2} \rceil  & \lceil -\tfrac{5}{2}
 \rceil & \lceil \tfrac{6}{2} \rceil & \dots \\ \\
 0 & 1 & -1 & 2 & -2 & 3 & \dots
 \end{array}
@@ -107,12 +107,12 @@ f(1) & f(2) & f(3) & f(4) & f(5) & f(6) & \dots \\ \\
 \end{ex}
 
 \begin{explain}
-That is fine for ``easy'' sets. What about the set of, say, pairs of 
-natural numbers?{} 
-\[ 
+That is fine for ``easy'' sets. What about the set of, say, pairs of
+natural numbers?{}
+\[
 \Nat^2 = \Nat \times \Nat = \Setabs{\tuple{n,m}}{n,m \in \Nat}
 \]
-Another method we can use to enumerate sets is to organize them 
+Another method we can use to enumerate sets is to organize them
 in an \emph{array}, such as the following:
 \[
 \begin{array}{ c | c | c | c | c | c}
@@ -130,10 +130,10 @@ in an \emph{array}, such as the following:
 \end{array}
 \]
 
-Clearly, every ordered pair in $\Nat^2$ will appear at least 
-once in the array. In particular, $\tuple{n,m}$ will appear in the $n$th 
-column and $m$th row. But how do we organize the elements of an 
-array into a list? The pattern in the array below demonstrates one 
+Clearly, every ordered pair in $\Nat^2$ will appear at least
+once in the array. In particular, $\tuple{n,m}$ will appear in the $n$th
+column and $m$th row. But how do we organize the elements of an
+array into a list? The pattern in the array below demonstrates one
 way to do this:
 \[
 \begin{array}{ c | c | c | c | c | c }
@@ -147,30 +147,30 @@ way to do this:
 \hline
 & 10 & \dots & \dots & \dots & \dots \\
 \hline
-& \vdots & \vdots & \vdots & \vdots & \ddots\\ 
+& \vdots & \vdots & \vdots & \vdots & \ddots\\
 \end{array}
 \]
-This pattern is called \emph{Cantor's zig-zag method}. Other 
-patterns are perfectly permissible, as long as they ``zig-zag'' 
-through every cell of the array. By Cantor's zig-zag method, the 
+This pattern is called \emph{Cantor's zig-zag method}. Other
+patterns are perfectly permissible, as long as they ``zig-zag''
+through every cell of the array. By Cantor's zig-zag method, the
 enumeration for $\Nat^2$ according to this scheme would be:
 \[
 \tuple{1,1}, \tuple{1,2}, \tuple{2,1}, \tuple{1,3}, \tuple{2,2}, \tuple{3,1}, \tuple{1,4}, \tuple{2,3}, \tuple{3,2}, \tuple{4,1}, \dots
 \]
 
-What ought we do about enumerating, say, the set of ordered triples 
+What ought we do about enumerating, say, the set of ordered triples
 of natural numbers?
-\[ 
-\Nat^3 = \Nat \times \Nat \times \Nat = \{ (n,m,k) : n,m,k \in \Nat \} 
+\[
+\Nat^3 = \Nat \times \Nat \times \Nat = \{ (n,m,k) : n,m,k \in \Nat \}
 \]
 We can think of $\Nat^3$ as the Cartesian product of
-$\Nat^2$ and $\Nat$, that is, 
-\[ 
-\Nat^3 = \Nat^2 \times \Nat = \Setabs{(\vec a, 
-k)}{\vec a \in \Nat^2, k \in \Nat } 
+$\Nat^2$ and $\Nat$, that is,
+\[
+\Nat^3 = \Nat^2 \times \Nat = \Setabs{(\vec a,
+k)}{\vec a \in \Nat^2, k \in \Nat }
 \]
-and thus we can enumerate $\Nat^3$ with an array by 
-labelling one axis with the enumeration of $\Nat$, and the 
+and thus we can enumerate $\Nat^3$ with an array by
+labelling one axis with the enumeration of $\Nat$, and the
 other axis with the enumeration of $\Nat^2$:
 \[
 \begin{array}{ c | c | c | c | c | c}
@@ -187,8 +187,8 @@ other axis with the enumeration of $\Nat^2$:
 \vdots & \vdots & \vdots & \vdots & \vdots & \ddots \\
 \end{array}
 \]
-Thus, by using a method like Cantor's zig-zag method, we may 
-similarly obtain an enumeration of~$\Nat^3$. 
+Thus, by using a method like Cantor's zig-zag method, we may
+similarly obtain an enumeration of~$\Nat^3$.
 \end{explain}
 
 \begin{prob}

--- a/sets-functions-relations/size-of-sets/equinumerous-sets.tex
+++ b/sets-functions-relations/size-of-sets/equinumerous-sets.tex
@@ -39,7 +39,7 @@ is a total bijection $f$ from $X$ to $Y$ (that is, $f \colon X
 \to Y$).
 \end{defn}
 
-\begin{prop} 
+\begin{prop}
 Equinumerosity defines an equivalence relation.
 \end{prop}
 
@@ -82,8 +82,8 @@ function (since functions are closed under composition). To see $g
 !!{surjective}, there is an $x \in X$ such that $g(x) = y$. Since $f$
 is !!{surjective}, there is an $n \in \Nat$ such that $f(n) =
 x$. Hence,
-\[ 
-(g \circ f)(n) = g(f(n)) = g(x) = y 
+\[
+(g \circ f)(n) = g(f(n)) = g(x) = y
 \]
 and thus $g \circ f$ is !!{surjective}. Since $g \circ f\colon \Nat
 \to Y$ is !!{surjective}, it is an enumeration of~$Y$, and so $Y$~is

--- a/sets-functions-relations/size-of-sets/non-enumerability.tex
+++ b/sets-functions-relations/size-of-sets/non-enumerability.tex
@@ -12,13 +12,13 @@
 
 Some sets, such as the set $\Nat$ of natural numbers, are infinite. So
 far we've seen examples of infinite sets which were all
-!!{enumerable}.  However, there are also infinite sets which do not
+!!{enumerable}. However, there are also infinite sets which do not
 have this property. Such sets are called \emph{!!{nonenumerable}}.
 
 Cantor's method of diagonalization shows a set to be !!{nonenumerable}
 via a reductio proof. We start with the assumption that the set is
 !!{enumerable}, and show that a contradiction results from this
-assumption.  Our first example is the set~$\Bin^\omega$ of all
+assumption. Our first example is the set~$\Bin^\omega$ of all
 infinite, non-gappy sequences of $0$'s and $1$'s.
 
 \begin{thm}
@@ -29,7 +29,7 @@ $\Bin^\omega$~is !!{nonenumerable}.
 \begin{proof}
 Suppose, for reductio, that $\Bin^\omega$ is !!{enumerable}, so that
 there is a list $s_{1}$, $s_{2}$, $s_{3}$, $s_{4}$, \dots{} of all the
-!!{element}s of~$\Bin^\omega$.  We may arrange this list, and the
+!!{element}s of~$\Bin^\omega$. We may arrange this list, and the
 elements of each sequence $s_i$ in it vertically in an array with the
 positive integers on the horizontal axis, as so:
 \[
@@ -49,7 +49,7 @@ Now define $\overline{s}$ as follows: The $n$th member
 $\overline{s}(n)$ of the sequence
 $\overline{s}$ is set to
 \[
-\overline{s}(n) = 
+\overline{s}(n) =
 \begin{cases}
 1 & \text{if $s_{n}(n) = 0$}\\
 0 & \text{if $s_{n}(n) = 1$}.
@@ -98,7 +98,7 @@ integer~$i$, $i \in \overline{Z}$ iff $i \notin Z_{i}$:
 
 $\overline{Z}$ is clearly a set of positive integers, and thus $\overline{Z}
 \in \Pow{\Int^+}$. So $\overline{Z}$ must be $= Z_k$ for some~$k \in
-\Int^+$.  And if that is the case, i.e., $\overline{Z} = Z_k$, then $i
+\Int^+$. And if that is the case, i.e., $\overline{Z} = Z_k$, then $i
 \in \overline{Z}$ iff $i \in Z_k$ for all~$i \in \Int^+$.
 
 In particular, $k \in \overline{Z}$ iff $k \in Z_k$.
@@ -107,10 +107,10 @@ Now either $k \in Z_{k}$ or $k \notin Z_{k}$. In the first case, by
 the previous line, $k \in \overline{Z}$. But we've defined
 $\overline{Z}$ so that it contains exactly those~$i \in \Int^+$ which
 are \emph{not} !!{element}s of~$Z_i$. So by that definition, we would
-have to also have~$k \notin Z_k$.  In the second case, $k \notin Z_k$.
+have to also have~$k \notin Z_k$. In the second case, $k \notin Z_k$.
 But now $k$~satisfies the condition by which we have
-defined~$\overline{Z}$, and that means that $k \in \overline{Z}$.  And
-as $\overline{Z} = Z_k$, we get that $k \in Z_k$ after all.  Either
+defined~$\overline{Z}$, and that means that $k \in \overline{Z}$. And
+as $\overline{Z} = Z_k$, we get that $k \in Z_k$ after all. Either
 case leads to a contradiction.
 \end{proof}
 

--- a/sets-functions-relations/size-of-sets/reduction.tex
+++ b/sets-functions-relations/size-of-sets/reduction.tex
@@ -27,10 +27,10 @@ $f(Z)$ be the sequence $s_{k}$ such that $s_{k}(j) = 1$ iff $j \in Z$.
 
 Every sequence of 0s and 1s corresponds to some set of positive
 integers, namely the one which has as its members those integers
-corresponding to the places where the the sequence has 1s. In other
+corresponding to the places where the sequence has 1s. In other
 words, this is !!a{surjective} function.
 
-Now consider the list 
+Now consider the list
 \[
 f(Z_1), f(Z_2), f(Z_3), \dots
 \]

--- a/turing-machines/machines-computations/configuration.tex
+++ b/turing-machines/machines-computations/configuration.tex
@@ -27,7 +27,7 @@ I\rangle$ is a triple $\langle C, n, q\rangle$ where
 \begin{enumerate}
 \item $C \in \Sigma^*$ is a finite sequence of symbols from $\Sigma$,
 \item $n \in \Nat$ is a number $\le \len{C}$, and
-\item $q \in Q$ 
+\item $q \in Q$
 \end{enumerate}
 \end{defn}
 
@@ -55,13 +55,13 @@ We say that a configuration $\langle C, n, q\rangle$ \emph{yields
 \begin{enumerate}
 \item the $n$-th symbol of $C$ is $\sigma$,
 \item the instruction set of $M$ contains a tuple $\langle q, \sigma,
-  q', \sigma', D\rangle$, 
+  q', \sigma', D\rangle$,
 \item the $n$-th symbol of $C'$ is $sigma'$,
-\item 
+\item
 \begin{enumerate}
 \item $D = L$ and $n' = n -1$, or
 \item $D = R$ and $n' = n$, or
-\item $D = N$ and $n' = n$, 
+\item $D = N$ and $n' = n$,
 \end{enumerate}
 \item for all $i \neq n$, $C'(i) = C(i)$,
 \item if $n' > \len{C}$, then $\len{C'} = \len{C} + 1$ and the $n'$-th
@@ -72,10 +72,10 @@ We say that a configuration $\langle C, n, q\rangle$ \emph{yields
 \begin{defn}
 A \emph{run of $M$ on input~$I$} is a sequence $C_i$ of configurations
 of $M$, where $C_0$ is the initial configuration of $M$ for input $I$,
-and each $C_i$ yields $C_{i+1}$ in one step.  
+and each $C_i$ yields $C_{i+1}$ in one step.
 
 We say that $M$ \emph{halts on input $I$ after $k$ steps} if $C_k =
-\langle \TMendtape \frown O, n, h\rangle$. In that case the
+\langle \TMendtape \frown O, n, h\rangle$.  In that case the
 \emph{output} of $M$ for input $I$ is $O$.
 \end{defn}
 

--- a/turing-machines/machines-computations/introduction.tex
+++ b/turing-machines/machines-computations/introduction.tex
@@ -20,7 +20,7 @@ direction (to the right), and it is divided into \emph{squares}, each
 of which may contain a symbol from a finite \emph{alphabet}.  Such
 alphabets can contain any number of different symbols, but we will
 mainly make do with three: $\TMendtape$, $\TMblank$, and
-$\mid$. When he mechanism is started, the tape is empty (i.e., each
+$\mid$.  When he mechanism is started, the tape is empty (i.e., each
 square contains the symbol $\TMblank$) except for the
 leftmost square, which contains $\TMendtape$, and a finite number
 of squares which contain the \emph{input}.  At any time, the mechanism
@@ -28,9 +28,9 @@ is in one of a finite number of \emph{states}.  At the outset, the
 head scans the leftmost square and in a specified \emph{initial
   state}.  At each step of the mechanism's run, the content of the
 square currently scanned together with the state the mechanism is in
-and the Turing machine program determine what happens next. The Turing
+and the Turing machine program determine what happens next.  The Turing
 machine program consists of a list of 5-tuples $\langle q_i, \sigma,
-q_j, \sigma', D\rangle$. Whenever the mechanism is in state $q_i$ and
+q_j, \sigma', D\rangle$.  Whenever the mechanism is in state $q_i$ and
 reads symbol $\sigma$, it replaces the symbol on the current square
 with $\sigma'$, the head moves left, right, or stays put according to
 whether $D$ is $L$, $R$, or $N$, and the mechanism goes into

--- a/turing-machines/machines-computations/turing-machines.tex
+++ b/turing-machines/machines-computations/turing-machines.tex
@@ -11,7 +11,7 @@
 
 \begin{explain}
 The formal definition of what constitutes a Turing machine looks
-abstract, but is actually very simple: it merely packs into one
+abstract, but is actually simple: it merely packs into one
 mathematical !!{structure} all the information needed to specify the
 workings of a Turing machine. This includes (1) which states the
 machine can be in, (2) which symbols are allowed to be on the tape, (3)
@@ -34,9 +34,9 @@ A \emph{Turing machine} $T = \langle Q, \Sigma, s, I\rangle$ consists of
 \begin{explain}
 We assume that the tape is infinite in one direction only. For this
 reason it is useful to designate a special symbol~$\TMendtape$ as
-a marker for the left end of the tape.  This makes it easier for
+a marker for the left end of the tape. This makes it easier for
 Turing machne programs to tell when they're ``in danger'' of running
-off the tape.  Other definitions of Turing machines are possible,
+off the tape. Other definitions of Turing machines are possible,
 including one where the tape is infinite in both directions. In that
 case, marker for the left end of the tape is not necessary.
 \end{explain}

--- a/turing-machines/machines-computations/unary-numbers.tex
+++ b/turing-machines/machines-computations/unary-numbers.tex
@@ -15,7 +15,7 @@ Depending on the alphabet a Turing machine uses, these sequences of
 symbols can represent various inputs and outputs.  Of particular
 interest, of course, are Turing machines which compute
 \emph{arithmetical} functions, i.e., functions of natural numbers.
-One very simple way to represent positive integers is by coding them
+A simple way to represent positive integers is by coding them
 as sequences of a single symbol~$\TMstroke$.
 \end{explain}
 

--- a/turing-machines/undecidability/decision-problems.tex
+++ b/turing-machines/undecidability/decision-problems.tex
@@ -38,7 +38,7 @@ or not.
 
 \begin{explain}
 We say that a decision problem is \emph{solvable} if there is such a
-procedure, and \emph{unsolvable} otherwise.  
+procedure, and \emph{unsolvable} otherwise.
 
 To show that a decision problem is solvable, you typically simply
 write down the procedure that solves it (and prove that it in fact
@@ -64,7 +64,7 @@ be reduced to a decision problem~B iff the answer to an instance of~A
 can be obtained by an answer to an instance of~B.  For instance, the
 problem of validity of a sentence can be reduced to that of
 satisfiability: Given a sentence~$!A$, form the sentence~$\lnot !A$:
-the former is valid iff the latter is not satisfiable. So the decision
+the former is valid iff the latter is not satisfiable.  So the decision
 problem for validity can be solved by taking an instance, transforming
 that instance into its negation by putting ``$\lnot$'' in front of it,
 obtaining the answer to ``Is $\lnot !A$ satisfiable?,'' and switching

--- a/turing-machines/undecidability/representing-tms.tex
+++ b/turing-machines/undecidability/representing-tms.tex
@@ -70,10 +70,10 @@ input $w$ are the following:
 \item The first $n$ squares contain the symbols $\triangleright$,
   $\sigma_{i_1}$, \dots, $\sigma_{i_n}$:
 \[
-\Obj S_\triangleright(\Obj 0, \Obj 0) \land 
-\Obj S_{i_1}(\overline 1, \Obj 0) \land 
+\Obj S_\triangleright(\Obj 0, \Obj 0) \land
+\Obj S_{i_1}(\overline 1, \Obj 0) \land
 \dots \land
-\Obj S_{i_n}(\overline n, \Obj 0) 
+\Obj S_{i_n}(\overline n, \Obj 0)
 \]
 \item Otherwise, the tape is empty:
 \[
@@ -88,7 +88,7 @@ For the following, let $A(x, y)$ be the conjunction of all sentences
 of the form
 \[
 \forall \Obj z(
-(\Obj z < \Obj x \lor \Obj x < \Obj z \land \Obj S_\sigma(\Obj z, \Obj y)) 
+(\Obj z < \Obj x \lor \Obj x < \Obj z \land \Obj S_\sigma(\Obj z, \Obj y))
 \lif \Obj S_\sigma(\Obj z, \Obj y'))
 \]
 where $\sigma \in \Sigma$.
@@ -97,7 +97,7 @@ where $\sigma \in \Sigma$.
 \[
 \lforall[\Obj x] \lforall[\Obj y](
    (\Obj Q_{q_i}(\Obj x', \Obj y) \land \Obj S_{\sigma}(\Obj x, \Obj y)) \lif
-   (\Obj Q_{q_j}(\Obj x, \Obj y) \land \Obj S_{\sigma'}(\Obj x, \Obj y) \land 
+   (\Obj Q_{q_j}(\Obj x, \Obj y) \land \Obj S_{\sigma'}(\Obj x, \Obj y) \land
 A(\Obj x, \Obj y)))
 \]
 \item For every instruction $\langle q_i, \sigma, q_j, \sigma',
@@ -105,7 +105,7 @@ A(\Obj x, \Obj y)))
 \[
 \lforall[\Obj x]\lforall[\Obj y](
    (\Obj Q_{q_i}(\Obj x, \Obj y) \land \Obj S_{\sigma}(\Obj x, \Obj y)) \lif
-   (\Obj Q_{q_j}(\Obj x', \Obj y) \land \Obj S_{\sigma'}(\Obj x, \Obj y) \land 
+   (\Obj Q_{q_j}(\Obj x', \Obj y) \land \Obj S_{\sigma'}(\Obj x, \Obj y) \land
 A(\Obj x, \Obj y)))
 \]
 \end{enumerate}

--- a/turing-machines/undecidability/verification.tex
+++ b/turing-machines/undecidability/verification.tex
@@ -17,7 +17,7 @@ descriptin of the configuration of $M$ for each step of the execution
 of $M$ on input $w$.  If $M$ halts on input $w$, then for some $n$,
 $M$ will be in a halting configuration at step $n$ (and be scanning
 square~$m$, for some $m$).  Hence, $T(M, w)$ implies $\Obj
-Q_h(\overline m, \overline n)$.  
+Q_h(\overline m, \overline n)$.
 \end{explain}
 
 \begin{defn}
@@ -55,7 +55,7 @@ $\sigma_k$.
 \begin{explain}
 To complete the verification of our clam, we also have to establish
 the reverse direction: if $T(M, w) \lif H(M, w)$ is valid, then $M$
-does in fact halt when started on input~$m$.  
+does in fact halt when started on input~$m$.
 \end{explain}
 
 \begin{lem}
@@ -73,13 +73,13 @@ $\Obj S_\sigma$ as follows:
 \Assign{\Obj S_\sigma}{M} & = \{(m, n) : \text{after $n$ steps, $M$ started
   on $w$ has symbol~$\sigma$ on square~$m$}\} \\
 \end{align*}
-Clearly, $\Sat{M}{T(M, w)}$. If $T(M, w)$ implies $H(M, w)$, then
+Clearly, $\Sat{M}{T(M, w)}$.  If $T(M, w)$ implies $H(M, w)$, then
 $\Sat{M}{H(M, w)}$, i.e.,
 \[
 \Sat{M}{\lexists[\Obj x]\lexists[\Obj y][\Obj{Q}_h(\Obj x, \Obj y)]}.
 \]
 As $\Domain{M} = \Nat$, there must be $m$, $n \in \Nat$ so that
-$\Sat{M}{\Obj Q_h(\overline{n}, \overline{m})}$. By the definition of
+$\Sat{M}{\Obj Q_h(\overline{n}, \overline{m})}$.  By the definition of
 $\Struct M$, this means that $M$ started on input~$w$ is in state~$h$
 after $m$ steps, i.e., has halted.
 \end{proof}


### PR DESCRIPTION
I've been working on a tool that automatically scans prose for errors in usage. I ran it on your book. This pull request fixes some of the issues that it found, including inconsistent spacing at the end of a sentence (rather than choose 1 vs. 2 for the whole book, I made all the pages consistent, one way or the other); the lexical illusion where the word "the" is repeated multiple times; overuse of the word "very", and a few other issues. I hope this is useful to you.