### PR TITLE
Modify notation in definition of isomorphism

### DIFF
--- a/content/sets-functions-relations/functions/isomorphic-functions.tex
+++ b/content/sets-functions-relations/functions/isomorphic-functions.tex
@@ -15,7 +15,7 @@ An \emph{isomorphism} is a bijection that preserves the structure of the sets it
 \end{explain}
 
 \begin{defn}
-Let U be the pair $\langle X, R\rangle$ and V be the pair $\langle Y, S\rangle$ such that $X$ and $Y$ are sets and $R$ and $S$ are relations on $X$ and $Y$ respectively. A bijection $f$ from $X$ to $Y$ is an \emph{isomorphism}  from U to V iff it preserves the relational structure, that is, for any $x$ and $u$ in $X$, $\langle x,u\rangle\in R$ iff $\langle f(x),f(u)\rangle\in S$.
+Let U be the pair $\langle X, R\rangle$ and V be the pair $\langle Y, S\rangle$ such that $X$ and $Y$ are sets and $R$ and $S$ are relations on $X$ and $Y$ respectively. A bijection $f$ from $X$ to $Y$ is an \emph{isomorphism}  from U to V iff it preserves the relational structure, that is, for any $x_{1}$ and $x_{2}$ in $X$, $\langle x_{1},x_{2}\rangle\in R$ iff $\langle f(x_{1}),f(x_{2})\rangle\in S$.
 \end{defn}
 
 \begin{ex}


### PR DESCRIPTION
Notation in definition of isomorphism is confusing (little u is not a
member of big U). Fixed.