### PR TITLE
Fix definition 'Initial Sequent'

### DIFF
--- a/content/first-order-logic/sequent-calculus/rules-and-proofs.tex
+++ b/content/first-order-logic/sequent-calculus/rules-and-proofs.tex
@@ -234,7 +234,7 @@ independent of~$a$.
 
 \begin{defn}[Initial Sequent]
 An \emph{initial sequent} is a sequent of the form $!A \Sequent !A$
-for any !!{sentence} $!A$ in the language.
+or $\quad \Sequent \ltrue$ or $\lfalse \Sequent \quad$ for any !!{sentence} $!A$ in the language.
 \end{defn}
 
 \begin{defn}[LK !!{derivation}]


### PR DESCRIPTION
We need to include '  => true' and 'false =>  ' as initial sequents in order to give 'true' and 'false' meaning.