### PR TITLE
Update 'First-order Logic'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@
 *.pdf
 *.gin
 *.prb
+*.pcr

--- a/content/first-order-logic/sequent-calculus/identity.tex
+++ b/content/first-order-logic/sequent-calculus/identity.tex
@@ -37,7 +37,7 @@ where $t_1$ and $t_2$ are closed terms.
 If $s$ and $t$ are ground terms, then $!A(s), \eq[s][t] \Proves[\Log{LK}] !A(t)$:
 \begin{prooftree}
 \Axiom$ !A(s) \fCenter !A(s)$
-\RightLabel{weak}
+\RightLabel{\LeftR{\Weakening}}
 \UnaryInf$ !A(s), \eq[s][t] \fCenter !A(s)$
 \RightLabel{$\eq$}
 \UnaryInf$ !A(s), \eq[s][t] \fCenter !A(t)$
@@ -48,21 +48,20 @@ identicals, or Leibniz' Law.
 $\Log{LK}$ proves that $\eq$ is symmetric and transitive:
 \[
 \Axiom$ \fCenter \eq[t_1][t_1] $
-\RightLabel{weak}
+\RightLabel{\LeftR{\Weakening}}
 \UnaryInf$ \eq[t_1][t_2] \fCenter \eq[t_1][t_1] $
 \RightLabel{$\eq$}
 \UnaryInf$ \eq[t_1][t_2] \fCenter \eq[t_2][t_1]$
 \DisplayProof
 \qquad
 \Axiom$ \eq[t_1][t_2] \fCenter \eq[t_1][t_2] $
-\RightLabel{weak}
+\RightLabel{\LeftR{\Weakening}}
 \UnaryInf$ \eq[t_1][t_2], \eq[t_2][t_3] \fCenter \eq[t_1][t_2] $
 \RightLabel{$\eq$}
 \UnaryInf$ \eq[t_1][t_2], \eq[t_2][t_3] \fCenter \eq[t_1][t_3]$
 \DisplayProof
 \]
-In the proof on the left, the !!{formula}~$\eq[x][t_1]$ is our $!A(x)$,
-and correspondingly, $!A(t_2) \ident \eq[\Subst{x}{t_2}{x}][t_1]$. On the
+In the proof on the left, the !!{formula}~$\eq[x][t_1]$ is our $!A(x)$. On the 
 right, we take $!A(x)$ to be $\eq[t_1][x]$.
 \end{ex}
 

--- a/content/first-order-logic/sequent-calculus/provability.tex
+++ b/content/first-order-logic/sequent-calculus/provability.tex
@@ -44,18 +44,12 @@ $\Log{LK}$ !!{derive}s $\Gamma_0 \Sequent !A$ and $\Gamma_1, !A
 \AxiomC{}
 \RightLabel{$\Pi_0$}
 \Deduce$ \Gamma_0 \fCenter !A $
-\doubleLine
-\UnaryInf$ \Gamma_0, \Gamma_1 \fCenter !A $
 \AxiomC{}
 \RightLabel{$\Pi_1$}
 \Deduce$ \Gamma_1, !A \fCenter \lfalse$
-\doubleLine
-\UnaryInf$ \Gamma_0, \Gamma_1, !A \fCenter \lfalse $
 \RightLabel{cut}
 \BinaryInf$ \Gamma_0,\Gamma_1 \fCenter \lfalse $
 \end{prooftree}
-(Recall that double inference lines indicate several weakening
-inferences.)
 
 Since $\Gamma_0 \subseteq \Gamma$ and $\Gamma_1 \subseteq \Gamma$,
 $\Gamma_0 \cup \Gamma_1 \subseteq \Gamma$, hence $\Gamma
@@ -78,7 +72,10 @@ consider
 \RightLabel{$\Pi_0$}
 \Deduce$\Gamma_0, !A \fCenter \lfalse$
 \RightLabel{\RightR{\lnot}}
-\UnaryInf$ \Gamma_0 \fCenter \lnot !A$
+\UnaryInf$ \Gamma_0 \fCenter \lfalse, \lnot !A$
+\AxiomC{$\lfalse \fCenter \quad$}
+\RightLabel{cut}
+\BinaryInf$ \Gamma_0 \fCenter \lnot !A$
 \end{prooftree}
 \end{proof}
 
@@ -99,7 +96,7 @@ of $\Gamma_0, !A \Sequent \lfalse$ and $\Gamma_1, \lnot !A \Sequent
 \RightLabel{$\Pi_0$}
 \Deduce$ \Gamma_0, !A \fCenter \lfalse $
 \RightLabel{\RightR{\lnot}}
-\UnaryInf$ \Gamma_0 \fCenter \lnot !A$
+\UnaryInf$ \Gamma_0 \fCenter \lfalse, \lnot !A$
 \AxiomC{}
 \RightLabel{$\Pi_1$}
 \Deduce$ \Gamma_1, \lnot !A \fCenter \lfalse $
@@ -136,6 +133,9 @@ $\Gamma_0 \cup \Gamma_1 \subseteq \Gamma$. Hence $\Gamma
 \RightLabel{\LeftR{\lor}}
 \BinaryInf$ \Gamma_0, \Gamma_1, !A \lor !B \fCenter \lfalse $
 \end{prooftree}
+(Recall that double inference lines indicate several weakening
+inferences.)
+
 Since $\Gamma_0,\Gamma_1\subseteq \Gamma$ and $\Gamma \cup \{!A \lor
 !B\} \Proves[\Log{LK}] \lfalse$.}
 \end{proof}
@@ -183,7 +183,7 @@ Prove \olref[fol][seq][prv]{prop:provability-lor-right}.
 \begin{prooftree}
 \AxiomC{}
 \RightLabel{$\Pi_0$}
-\Deduce$ \Gamma_0, \fCenter !A \land !B$
+\Deduce$ \Gamma_0 \fCenter !A \land !B$
 \Axiom$!A \fCenter !A$
 \RightLabel{\LeftR{\land}}
 \UnaryInf$!A \land !B \fCenter !A$
@@ -214,10 +214,14 @@ and $\Gamma \Proves[\Log{LK}] !B$, then $\Gamma \Proves[\Log{LK}] !A
 \begin{prooftree}
 \AxiomC{}
 \RightLabel{$\Pi_0$}
-\Deduce$ \Gamma_0, \fCenter !A$
+\Deduce$ \Gamma_0 \fCenter !A$
+\doubleLine
+\UnaryInf$ \Gamma_0, \Gamma_1 \fCenter !A$
 \AxiomC{}
 \RightLabel{$\Pi_1$}
-\Deduce$ \Gamma_1, \fCenter !B$
+\Deduce$ \Gamma_1 \fCenter !B$
+\doubleLine
+\UnaryInf$ \Gamma_0, \Gamma_1 \fCenter !B$
 \RightLabel{\RightR{\land}}
 \BinaryInf$\Gamma_0, \Gamma_1 \fCenter !A \land !B $
 \end{prooftree}
@@ -246,14 +250,10 @@ $\Gamma \Proves[\Log{LK}] !A \lif !B$, then $\Gamma \Proves[\Log{LK}]
 \AxiomC{}
 \RightLabel{$\Pi_0$}
 \Deduce$ \Gamma_1 \fCenter !A \lif !B$
-\doubleLine
-\UnaryInf$ \Gamma_0, \Gamma_1, \Gamma_2 \fCenter !A \lif !B$
 \AxiomC{}
 \RightLabel{$\Pi_1$}
 \Deduce$\Gamma_0 \fCenter !A $
 \AxiomC{$!B \fCenter !B$}
-\doubleLine
-\UnaryInf$ \Gamma_0, !B \fCenter !B$
 \RightLabel{\LeftR{\lif}}
 \BinaryInf$\Gamma_0, !A \lif !B \fCenter !B$
 \RightLabel{cut}
@@ -286,7 +286,7 @@ or $\Gamma \Proves[\Log{LK}] !B$, then $\Gamma \Proves[\Log{LK}] !A
 \Axiom$!A \fCenter !A$
 \RightLabel{\RightR{\lnot}}
 \UnaryInf$\lnot !A, !A \fCenter$
-\doubleLine
+\RightLabel{\RightR{\Weakening}}
 \UnaryInf$!A, \lnot !A \fCenter !B$
 \RightLabel{\RightR{\lif}}
 \UnaryInf$\lnot !A \fCenter !A \lif !B$
@@ -303,7 +303,7 @@ $\Gamma_0 \Sequent !B$. The following !!{derivation} shows that $\Gamma
 \RightLabel{$\Pi_0$}
 \Deduce$\Gamma_0 \fCenter !B$
 \Axiom$!B \fCenter !B$
-\doubleLine
+\RightLabel{\LeftR{\Weakening}}
 \UnaryInf$!A, !B \fCenter !B$
 \RightLabel{\RightR{\lif}}
 \UnaryInf$!B \fCenter !A \lif !B$
@@ -324,8 +324,8 @@ in $\Gamma$ or $!A(x)$ and $\Gamma \Proves[\Log{LK}] !A(c)$, then $\Gamma
 
 \begin{proof}
 Let $\Pi_0$ be an $\Log{LK}$-!!{derivation} of $\Gamma_0 \Sequent !A(c)$
-for some finite $\Gamma_0 \subseteq \Gamma$.  By adding a $\lforall$
-right inference, we obtain a proof of $\Gamma \Sequent
+for some finite $\Gamma_0 \subseteq \Gamma$.  By adding a
+$\RightR{\lforall}$ inference, we obtain a proof of $\Gamma \Sequent
 \lforall[x][!A(x)]$, since $c$ does not occur in $\Gamma$ or $!A(x)$
 and thus the eigenvariable condition is satisfied.
 \end{proof}
@@ -348,7 +348,7 @@ and thus the eigenvariable condition is satisfied.
   \Sequent !A(t)$. Add an \RightR{\lexists} inference to get
   !!a{derivation} of $\Gamma_0 \Sequent \lexists[x][!A(x)]$.}{}
 
-\tagitem{prvAll}{Suppose $\Gamma \Proves[\Log{LK}] \lnot !A(t)$. Then there is a
+\tagitem{prvAll}{Suppose $\Gamma \Proves[\Log{LK}] \lforall[x][!A(x)]$. Then there is a
   finite $\Gamma_0 \subseteq \Gamma$ and an $\Log{LK}$-!!{derivation}
   $\Pi$ of $\Gamma_0 \Sequent \lforall[x][!A(x)]$.  Then
 % for some reason, prooftree env sometimes doesn't work here
@@ -365,7 +365,7 @@ and thus the eigenvariable condition is satisfied.
 %\end{prooftree}
 \DisplayProof
 \]
-shows that $\Gamma_0 \Proves[\Log{LK}] !A(t)$.}{}
+shows that $\Gamma \Proves[\Log{LK}] !A(t)$.}{}
 \end{tagenumerate}
 \end{proof}
 \end{document}

--- a/content/first-order-logic/sequent-calculus/proving-things.tex
+++ b/content/first-order-logic/sequent-calculus/proving-things.tex
@@ -23,8 +23,8 @@ sequent of this form. This could be a structural rule, but it is a
 good idea to start by looking for a logical rule. The only logical
 connective occurring in a !!{formula} in the lower sequent is $\land$,
 so we're looking for an $\land$ rule, and since the $\land$ symbol
-occurs in the antecedent !!{formula}s, we're looking at the $\land$
-left rule.
+occurs in the antecedent !!{formula}s, we're looking at the \LeftR{\land}
+rule.
 \begin{prooftree}
 \AxiomC{}
 \RightLabel{\LeftR{\land}} \UnaryInf$!A\land !B \fCenter !A$
@@ -58,8 +58,8 @@ they are !!{main operator}s of !!{sentence}s in the end-sequent,
 while $\lnot$ is inside the scope of another connective, so we will
 take care of it later. Our options for logical rules for the final
 inference are therefore the \LeftR{\lor} rule and the \RightR{\lif}
-rule. We could pick either rule, really, but let's pick the $\lif$
-right rule (if for no reason other than it allows us to put off
+rule. We could pick either rule, really, but let's pick the \RightR{\lif}
+rule (if for no reason other than it allows us to put off
 splitting into two branches). According to the form of \RightR{\lif}
 inferences which can yield the lower sequent, this must look like:
 \begin{prooftree}
@@ -142,8 +142,8 @@ branches for a moment:
 \UnaryInf$\lnot !A \lor \lnot !B \fCenter \lnot (!A \land !B)$
 \end{prooftree}
 Now we have a choice of whether to look at the \LeftR{\land} or the
-\LeftR{\lor} rule. Let's see what happens when we apply the $\land$
-left rule: we have a choice to start with either the sequent $!A,
+\LeftR{\lor} rule. Let's see what happens when we apply the \LeftR{\land}
+rule: we have a choice to start with either the sequent $!A,
 \lnot !A \lor !B \Sequent \hspace{1em}$ or the sequent $!B, \lnot !A
 \lor !B \Sequent \hspace{1em}$. Since the proof is symmetric with
 regards to $!A$ and $!B$, let's go with the former:
@@ -239,14 +239,13 @@ later, so we'll do that one first.
 \RightLabel{\LeftR{\lexists}}
 \UnaryInf$ \lexists[x][\lnot !A(x)] \fCenter \lnot \lforall[x][!A(x)]$
 \end{prooftree}
-Applying the \LeftR{\lnot} and right rules to eliminate the $\lnot$ signs, we get
+Applying the \LeftR{\lnot} and \RightR{\lnot} rules and then eliminating
+the double $\lnot$ signs on both sides---the reader may do this as an 
+exercise---we get
 \begin{prooftree}
 \AxiomC{}
 \UnaryInf$\lforall[x][!A(x)] \fCenter !A(a)$
-\RightLabel{\RightR{\lnot}}
-\UnaryInf$ \fCenter \lnot \lforall[x][!A(x)], !A(a)$
-\RightLabel{\LeftR{\lnot}}
-\UnaryInf$ \lnot !A(a) \fCenter \lnot \lforall[x] !A(x)$
+\Deduce$ \lnot !A(a) \fCenter \lnot \lforall[x] !A(x)$
 \RightLabel{\LeftR{\lexists}}
 \UnaryInf$ \lexists[x] \lnot !A(x) \fCenter \lnot \lforall[x] !A(x)$
 \end{prooftree}
@@ -259,10 +258,7 @@ as our argument for $!A$ when we apply the rule.
 \Axiom$!A(a) \fCenter !A(a)$
 \RightLabel{\LeftR{\lforall}}
 \UnaryInf$\lforall[x][!A(x)] \fCenter !A(a)$
-\RightLabel{\RightR{\lnot}}
-\UnaryInf$ \fCenter \lnot \lforall[x][!A(x)], !A(a)$
-\RightLabel{\LeftR{\lnot}}
-\UnaryInf$ \lnot !A(a) \fCenter \lnot \lforall[x][!A(x)]$
+\Deduce$ \lnot !A(a) \fCenter \lnot \lforall[x][!A(x)]$
 \RightLabel{\LeftR{\lexists}}
 \UnaryInf$ \lexists[x][ \lnot !A(x)] \fCenter \lnot \lforall[x][!A(x)]$
 \end{prooftree}

--- a/content/first-order-logic/sequent-calculus/rules-and-proofs.tex
+++ b/content/first-order-logic/sequent-calculus/rules-and-proofs.tex
@@ -244,13 +244,11 @@ An \emph{initial sequent} is a sequent
 \end{defn}
 
 \begin{defn}[LK !!{derivation}]
-An \emph{$\Log{LK}$-!!{derivation}} of a sequent $S$ is a tree of sequents
-satisfying the following conditions:
+An \emph{$\Log{LK}$-!!{derivation}} of a sequent $S$ is a tree of sequents 
+with $S$ at the root satisfying the following conditions:
 \begin{enumerate}
-\item The topmost sequents of the tree are initial sequents.
-\item Every sequent in the tree (except $S$) is an upper sequent of an
-  inference whose lower sequent stands directly below that sequent in
-  the tree.
+\item The leaves of the tree are initial sequents.
+\item The children of a node infer the parent using one of the inference rules.
 \end{enumerate}
 We then say that $S$ is the \emph{end-sequent} of the !!{derivation} and
 that $S$ is \emph{!!{derivable} in $\Log{LK}$} (or $\Log{LK}$-!!{derivable}).

--- a/content/first-order-logic/sequent-calculus/soundness.tex
+++ b/content/first-order-logic/sequent-calculus/soundness.tex
@@ -51,17 +51,17 @@ satisfies it.
 
 \begin{proof}
 Let $\Pi$ be a !!{derivation} of $\Gamma \Sequent \Delta$. We proceed by
-induction on the number of inferences in~$\Pi$.
+induction on the height of the proof tree $\Pi$.
 
-If the number of inferences is~0, then $\Pi$ consists only of an
+If the height is~1, then $\Pi$ consists only of an
 initial sequent. Every initial sequent $!A \Sequent !A$ is obviously
 valid, since for every $\Struct M$, either $\Sat/{M}{!A}$ or
 $\Sat{M}{!A}$.
 
-If the number of inferences is greater than~0, we distinguish cases
-according to the type of the lowermost inference. By induction
+If the height $n$ is greater than~$1$, we distinguish cases
+according to the type of the inference at the root. By induction
 hypothesis, we can assume that the premises of that inference are
-valid.
+valid, since the height of the proof of any premise is smaller than $n$.
 
 First, we consider the possible inferences with only one premise
 $\Gamma' \Sequent \Delta'$.
@@ -77,7 +77,7 @@ $\Gamma' \Sequent \Delta'$.
   $\Sat{M}{!E}$ for some $!E \in \Delta$.  Since $\Gamma' \Sequent
   \Delta'$ is valid, one of these cases obtains for every~$\Struct
   M$. Consequently, $\Gamma \Sequent \Delta$ is valid.
-\item The last inference is $\lnot$~left: Then for some $!A \in
+\item The last inference is \LeftR{\lnot}: Then for some $!A \in
   \Delta'$, $\lnot !A \in \Gamma$.  Also, $\Gamma' \subseteq \Gamma$,
   and $\Delta' \setminus \{!A\} \subseteq \Delta$.
 
@@ -89,8 +89,8 @@ $\Gamma' \Sequent \Delta'$.
   for some $!E \in \Gamma$ (since $\Gamma' \subseteq \Gamma$) or
   $\Sat{M}{!E}$ for some $!E \in \Delta'$ different from~$!A$ (since
   $\Delta' \setminus \{!A\} \subseteq \Delta$).
-\item The last inference is $\lnot$~right: Exercise.
-\item The last inference is $\land$~left: There are two variants: $!A
+\item The last inference is \RightR{\lnot}: Exercise.
+\item The last inference is \LeftR{\land}: There are two variants: $!A
   \land !B$ may be inferred on the left from $!A$ or from $!B$ on the
   left side of the premise.  In the first case, $!A \in \Gamma'$.
   Consider a !!{structure}~$\Struct M$.  Since $\Gamma' \Sequent
@@ -105,7 +105,7 @@ $\Gamma' \Sequent \Delta'$.
   $\Struct M$ was arbitrary, $\Gamma \Sequent \Delta$ is valid.  The
   case where $!A \land !B$ is inferred from $!B$ is handled the same,
   changing $!A$ to $!B$.
-\item The last inference is $\lor$~right: There are two variants: $!A
+\item The last inference is \RightR{\lor}: There are two variants: $!A
   \lor !B$ may be inferred on the right from $!A$ or from $!B$ on the
   right side of the premise.  In the first case, $!A \in \Delta'$.
   Consider a !!{structure}~$\Struct M$.  Since $\Gamma' \Sequent
@@ -119,7 +119,7 @@ $\Gamma' \Sequent \Delta'$.
   \Delta$.  Since $\Struct M$ was arbitrary, $\Gamma \Sequent \Delta$
   is valid.  The case where $!A \lor !B$ is inferred from $!B$ is
   handled the same, changing $!A$ to $!B$.
-\item The last inference is $\lif$~right: Then $!A \in \Gamma'$, $!B
+\item The last inference is \RightR{\lif}: Then $!A \in \Gamma'$, $!B
   \in \Delta'$, $\Gamma' \setminus \{!A\} \subseteq \Gamma$ and
   $\Delta' \setminus \{!B\} \subseteq \Delta$.  Since $\Gamma'
   \Sequent \Delta'$ is valid, for any !!{structure}~$\Struct M$, (a)
@@ -130,7 +130,7 @@ $\Gamma' \Sequent \Delta'$.
   case (d), for some $!E \in \Delta$, $\Sat{M}{!E}$.  In each case,
   $\Struct M$ satisfies $\Gamma \Sequent \Delta$.  Since $\Struct M$
   was arbitrary, $\Gamma \Sequent \Delta$ is valid.
-\item The last inference is $\forall$~left: Then there is a
+\item The last inference is \LeftR{\lforall}: Then there is a
   !!{formula}~$!A(x)$ and a ground term~$t$ such that $!A(t) \in
   \Gamma'$, $\lforall[x][!A(x)] \in \Gamma$, and $\Gamma' \setminus
   \{!A(t)\} \subseteq \Gamma$.  Consider a !!{structure}~$\Struct
@@ -143,8 +143,8 @@ $\Gamma' \Sequent \Delta'$.
   $\Sat{M}{!E}$, as $\Delta = \Delta'$.  So in each case, $\Struct M$
   satisfies $\Gamma \Sequent \Delta$.  Since $\Struct M$ was arbitrary,
   $\Gamma \Sequent \Delta$ is valid.
-\item The last inference is $\lexists$~right: Exercise.
-\item The last inference is $\forall$~right: Then there is a
+\item The last inference is \RightR{\lexists}: Exercise.
+\item The last inference is \RightR{\lforall}: Then there is a
   !!{formula}~$!A(x)$ and a !!{constant}~$a$ such that $!A(a) \in
   \Delta'$, $\lforall[x][!A(x)] \in \Delta$, and $\Delta' \setminus
   \{!A(a)\} \subseteq \Delta$.  Furthermore, $a \notin \Gamma \cup
@@ -187,10 +187,9 @@ $\Gamma' \Sequent \Delta'$.
   an $!E \in \Delta' \setminus \{!A(a)\}$ such that $\Sat{M}{!E}$.  So
   in each case, $\Struct M$ satisfies $\Gamma \Sequent \Delta$.  Since
   $\Struct M$ was arbitrary, $\Gamma \Sequent \Delta$ is valid.
-\item The last inference is $\lexists$~left: Exercise.
+\item The last inference is \LeftR{\lexists}: Exercise.
 \end{enumerate}
-Now let's consider the possible inferences with two premises: cut,
-$\lor$~left, $\land$~right, and $\lif$~left.
+Now let's consider the possible inferences with two premises.
 \begin{enumerate}
 \item The last inference is a cut: Suppose the premises are $\Gamma'
   \Sequent \Delta'$ and $\Pi' \Sequent \Lambda'$ and the cut formula
@@ -205,7 +204,7 @@ $\lor$~left, $\land$~right, and $\lif$~left.
   \setminus \{!A\} \Sequent \Lambda'$.  But $\Pi' \setminus \{!A\}
   \subseteq \Gamma$ and $\Lambda' \subseteq \Delta$, so $\Struct M$
   also satisfies $\Gamma \Sequent \Delta$.
-\item The last inference is $\land$~right.  The premises are $\Gamma
+\item The last inference is \RightR{\land}.  The premises are $\Gamma
   \Sequent \Delta'$ and $\Gamma \Sequent \Delta''$, where $!A \in
   \Delta'$ an $!B \in \Delta''$.  By induction hypothesis, both are
   valid.  Consider a !!{structure}~$\Struct M$.  We have two cases:
@@ -219,8 +218,8 @@ $\lor$~left, $\land$~right, and $\lif$~left.
   $\Struct M$ satisfies $\Gamma \Sequent \Delta$.  In case (b),
   $\Struct M$ satisfies $\Gamma \Sequent \Delta$ since $!A \land !B
   \in \Delta$.
-\item The last inference is $\lor$~left: Exercise.
-\item The last inference is $\lif$~left.  The premises are $\Gamma
+\item The last inference is \LeftR{\lor}: Exercise.
+\item The last inference is \LeftR{\lif}.  The premises are $\Gamma
   \Sequent \Delta'$ and $\Gamma' \Sequent \Delta$, where $!A \in
   \Delta'$ and $!B \in \Gamma'$.  By induction hypothesis, both are
   valid.  Consider a !!{structure}~$\Struct M$.  We have two cases:
@@ -255,7 +254,7 @@ If $\Gamma \Proves[\Log{LK}] !A$ then for some finite subset $\Gamma_0 \subseteq
 \Gamma$, there is !!a{derivation} of $\Gamma_0 \Sequent !A$.  By
 \olref{sequent-soundness}, every !!{structure} $\Struct M$ either
 makes some $!B \in \Gamma_0$ false or makes $!A$ true.  Hence, if
-$\Sat{M}{\Gamma_0}$ then also $\Sat{M}{!A}$.
+$\Sat{M}{\Gamma}$ then also $\Sat{M}{!A}$.
 \end{proof}
 
 \begin{cor}


### PR DESCRIPTION
This change removes the need for special eigenvalue constants. In fact,
they are not necessary as we can have the same without them if we
modify the definitions of satisfiability, entailment and validity of a
sequent and change the inference rules, so that a eigenvariable is
just an ordinary variable (of course with the same eigenvariable
condition). As of now, the introduction of these special eigenvalue
constants is not done properly, for example: how a sentence with such
an constant were to be evaluated if it contains a constant not in the
language? As it is in fact very unnatural to extend the language, the
proposed approach seems to be preferred.

Also this change fixes some proof trees and other small things, and
includes rewrites of some proofs, most notably the soundness proof.
The proofs should be revised, though, as the phrasing is clumsy and the
case analyses should be made clearer.

The change only includes the sequent calculus; the remaining chapters
would need to be adjusted as well.