### PR TITLE
Fixing a typo in the outline of firstorder completeness

### DIFF
--- a/content/first-order-logic/completeness/outline.tex
+++ b/content/first-order-logic/completeness/outline.tex
@@ -69,9 +69,9 @@ There is one wrinkle in this plan: if $\lexists[x][!A(x)] \in \Gamma$
 we would hope to be able to pick some !!{constant}~$c$ and add $!A(c)$
 in this process.  But how do we know we can always do that?  Perhaps we
 only have a few !!{constant}s in our language, and for each one of
-them we have $\lnot !B(c) \in \Gamma$.  We can't also add $!B(c)$,
+them we have $\lnot !A(c) \in \Gamma$.  We can't also add $!A(c)$,
 since this would make the set inconsistent, and we wouldn't know
-whether $\Struct{M}$ has to make $!B(c)$ or $\lnot !B(c)$ true.
+whether $\Struct{M}$ has to make $!A(c)$ or $\lnot !A(c)$ true.
 Moreover, it might happen that $\Gamma$ contains only sentences in a
 language that has no constant symbols at all (e.g., the language of
 set theory).


### PR DESCRIPTION
Fixes #156