### PR TITLE
Increase reserved space for section numbers in toc

### DIFF
--- a/sty/open-logic.sty
+++ b/sty/open-logic.sty
@@ -26,6 +26,10 @@
 \RequirePackage{wrapfig}
 \RequirePackage{catchfile}
 \RequirePackage{tocloft}
+% Increase the space reserved for the section numbers in the table of contents
+% (else some entries will look like "10.11Soundness" without any separation
+% between the number and the title)
+\setlength\cftsectionnumwidth{2.7em}
 
 \RequirePackage{xcolor}
 \definecolor{dark-gray}{gray}{0.2}


### PR DESCRIPTION
At the moment, some entries in the table of contents look like this:

    10.11Soundness . . . . . . . . . 134

This commit increases the reserved space for section numbers, such that such entries now look like this:

    10.11  Soundness . . . . . . . . 134