### PR TITLE
Correct typo in normal modal logic chapter on frame definability.

### DIFF
--- a/content/normal-modal-logic/frame-definability/first-order-definability.tex
+++ b/content/normal-modal-logic/frame-definability/first-order-definability.tex
@@ -15,7 +15,7 @@ frames can be defined by modal !!{formula}s. For instance, symmetry of
 frames can be defined by the !!{formula}~\Ax{B}, $p \lif \Box\Diamond
 p$. The conditions we've encountered so far can all be expressed by
 first-order !!{formula}s in !!a{language} involving a single two-place
-!!{predicate}. For instance, symmmetry is defined by
+!!{predicate}. For instance, symmetry is defined by
 $\lforall[x][\lforall[y][(\Atom{Q}{x,y} \lif \Atom{Q}{y, x})]]$ in the
 sense that a first-order !!{structure}~$\Struct{M}$ with $\Domain{M} =
 W$ and $\Assign{Q}{M} = R$ satisfies the preceding formula iff $R$ is


### PR DESCRIPTION
Correct typo in "First-order Definability" section of the normal modal logic chapter "Frame definability".