### PR TITLE
Fix the proof in Proposition 2.12

### DIFF
--- a/content/sets-functions-relations/relations/equivalence-relations.tex
+++ b/content/sets-functions-relations/relations/equivalence-relations.tex
@@ -55,7 +55,7 @@ $\equivrep{y}{R} \subseteq \equivrep{x}{R}$. So $\equivrep{x}{R} =
 \equivrep{y}{R}$, by extensionality.
 
 For the right-to-left direction, suppose $\equivrep{x}{R} =
-\equivrep{y}{R}$. Since $R$ is symmetric, $Ryy$, so $y \in
+\equivrep{y}{R}$. Since $R$ is reflexive, $Ryy$, so $y \in
 \equivrep{y}{R}$. Thus also $y \in \equivrep{x}{R}$ by the assumption
 that $\equivrep{x}{R} = \equivrep{y}{R}$. So $Rxy$.
 \end{proof}


### PR DESCRIPTION
The text currently says "Since R is symmetric, Ryy". Should not it be "Since R is reflexive, Ryy"? Because, if we want to say Ryy, we need the relation to be reflexive, not symmetric.