### PR TITLE
Fix explanation on |x| being undifferentiable

### DIFF
--- a/content/history/set-theory/limits.tex
+++ b/content/history/set-theory/limits.tex
@@ -68,7 +68,7 @@ It is important, though, to realise why our definition needs the
 caveat ``where a limit exists''. To take a simple example, consider
 $f(x) = |x|$, whose graph we just saw. Evidently, $f'(0)$ is
 ill-defined: if we approach $0$ ``from the right'', the gradient is
-always $1$; if we approach $0$ ``from the right'', the gradient is
+always $1$; if we approach $0$ ``from the left'', the gradient is
 always $-1$; so the limit is undefined. As such, we might add that a
 function~$f$ is \emph{differentiable} at~$x$ iff such a limit exists.
 


### PR DESCRIPTION
This seems to be a copy-paste typo where the left-handed limit was confused with the right-handed one.