### PR TITLE
Fix table label

### DIFF
--- a/content/normal-modal-logic/tableaux/more-rules.tex
+++ b/content/normal-modal-logic/tableaux/more-rules.tex
@@ -152,8 +152,8 @@ the logics given in \olref{tab:logics-rules}.
       \\ \hline
     \end{tabular}
   \end{center}
-  \ollabel{tab:logics-rules}
   \caption{!!^{tableau} rules for various modal logics.}
+  \ollabel{tab:logics-rules}
 \end{table}
   
 \end{document}


### PR DESCRIPTION
As far I know, label for the table must be specified **after** the caption. Currently, reference `\olref{tab:logics-rules}` in text incorrectly renders as "section 6.5" instead of "table 6.4" (Boxes and Diamonds, p.103).