### PR TITLE
Fixes to the definition of enumarable in second-order logic chapter

### DIFF
--- a/content/second-order-logic/metatheory/loewenheim-skolem.tex
+++ b/content/second-order-logic/metatheory/loewenheim-skolem.tex
@@ -35,11 +35,11 @@ Recall that
       \lforall[x][(X(x) \lif X(u(x)))]) \lif \lforall[x][X(x)])]]]
 \]
 is true in !!a{structure}~$\Struct{M}$ iff $\Domain{M}$ is
-!!{enumerable}. So $\fn{Inf} \land \lnot\fn{Count}$ is true in~$\Struct{M}$
-iff $\Domain{M}$ is both infinite and not !!{enumerable}.  There are
+!!{enumerable}, so $\lnot\fn{Count}$ is true in~$\Struct{M}$
+iff $\Domain{M}$ is !!{nonenumerable}.  There are
 such !!{structure}s---take any !!{nonenumerable} set as the
-!!{domain}, e.g., $\Pow{\Nat}$ or~$\Real$. So $\fn{Inf} \land
-\lnot \fn{Count}$ has infinite models but no !!{enumerable} models.
+!!{domain}, e.g., $\Pow{\Nat}$ or~$\Real$. So $\lnot \fn{Count}$ 
+has infinite models but no !!{enumerable} models.
 \end{proof}
 
 \begin{thm}

--- a/content/second-order-logic/syntax-and-semantics/inf-count.tex
+++ b/content/second-order-logic/syntax-and-semantics/inf-count.tex
@@ -60,7 +60,7 @@ A set $M$ is !!{enumerable} if there is an enumeration
 \[
 m_0, m_1, m_2, \dots
 \]
-of its !!{element}s (possibly with repetitions).  Such an enumeration exists
+of its !!{element}s (without repetitions but possibly finite).  Such an enumeration exists
 iff there is !!a{element} $z \in M$ and a function $f\colon M \to M$
 such that $z$, $f(z)$, $f(f(z))$, \dots, are all the !!{element}s of~$M$. For
 if the enumeration exists, $z = m_0$ and $f(m_k) = m_{k+1}$ (or

--- a/content/second-order-logic/syntax-and-semantics/inf-count.tex
+++ b/content/second-order-logic/syntax-and-semantics/inf-count.tex
@@ -60,7 +60,7 @@ A set $M$ is !!{enumerable} if there is an enumeration
 \[
 m_0, m_1, m_2, \dots
 \]
-of its !!{element}s (without repetitions).  Such an enumeration exists
+of its !!{element}s (possibly with repetitions).  Such an enumeration exists
 iff there is !!a{element} $z \in M$ and a function $f\colon M \to M$
 such that $z$, $f(z)$, $f(f(z))$, \dots, are all the !!{element}s of~$M$. For
 if the enumeration exists, $z = m_0$ and $f(m_k) = m_{k+1}$ (or

--- a/content/second-order-logic/syntax-and-semantics/inf-count.tex
+++ b/content/second-order-logic/syntax-and-semantics/inf-count.tex
@@ -62,7 +62,7 @@ m_0, m_1, m_2, \dots
 \]
 of its !!{element}s (without repetitions).  Such an enumeration exists
 iff there is !!a{element} $z \in M$ and a function $f\colon M \to M$
-such that $z$, $f(z)$, $f(f(z))$ are all the !!{element}s of~$M$. For
+such that $z$, $f(z)$, $f(f(z))$, \dots, are all the !!{element}s of~$M$. For
 if the enumeration exists, $z = m_0$ and $f(m_k) = m_{k+1}$ (or
 $f(m_k) = m_k$ if $m_k$ is the last !!{element} of the enumeration)
 are the requisite !!{element} and function. On the other hand, if such


### PR DESCRIPTION
A slight confusion regarding the definition of an enumerable set in the chapter on second-order logic is fixed. 