### PR TITLE
Fix figure label

### DIFF
--- a/content/turing-machines/machines-computations/introduction.tex
+++ b/content/turing-machines/machines-computations/introduction.tex
@@ -54,9 +54,9 @@ state~$q'$.
 
 For instance, consider the situation in \olref{fig:tm}.
 \begin{figure}
-  \ollabel{fig:tm}
   \olasset{\olpath/assets/diagrams/turing-machine.tikz}
   \caption{A Turing machine executing its program.}
+  \ollabel{fig:tm}
 \end{figure}
 The visible part of the tape of the Turing machine contains the
 end-of-tape symbol $\TMendtape$ on the leftmost square, followed by


### PR DESCRIPTION
This PR moves the figure label after the caption. Seems like you've missed that one in 8af09b4237520f51766978a4b2f82ee77633e3cb after my previous PR #218.