### PR TITLE
Fixed typo in definition of cumulative hierarchy

### DIFF
--- a/content/set-theory/spine/idea.tex
+++ b/content/set-theory/spine/idea.tex
@@ -18,7 +18,7 @@ definition:
 	V_\emptyset &:= \emptyset\\
 	V_{\ordsucc{\alpha}} &:= \Pow{V_\alpha} & & 
 	\text{for any ordinal }\alpha\\
-	V_{\alpha} &:= \bigcup_{\gamma < \alpha} V_\alpha & & 
+	V_{\alpha} &:= \bigcup_{\gamma < \alpha} V_\gamma & & 
 	\text{when }\alpha\text{ is a limit ordinal}
 \end{align*}
 \end{defn}


### PR DESCRIPTION
The limit case of the definition of cumulative hierarchy had an alpha where there should have been a gamma.