### PR TITLE
Remove irrelevant objects from Theorem 7.6 

### DIFF
--- a/content/sets-functions-relations/infinite/dedekind-induction.tex
+++ b/content/sets-functions-relations/infinite/dedekind-induction.tex
@@ -14,12 +14,7 @@ algebra---will serve as a surrogate for the natural numbers. This is
 thanks to the following trivial consequence:
 
 \begin{thm}[Arithmetical induction]\ollabel{thm:dedinfiniteinduction}
-Let $N, s, o$ yield a Dedekind algebra. Then for any set $X$: % for
-any formula $\phi(x, \overline{v})$ and any sets
-$\overline{c}$:\footnote{This may be new notation for you. We write
-$\phi(x, v_1, \ldots, v_n)$ as $\phi(x, \overline{v})$; and if we have
-sets $c_1, \ldots, c_n$, we can write $\phi(x, \overline{c})$ in place
-of $\phi(x, c_1, \ldots, c_n)$.} 
+Let $N, s, o$ yield a Dedekind algebra. Then for any set $X$:  
 	\begin{center}
 		if $o \in X$ and $(\forall {n} \in N \cap X){s}({n}) \in X$, {then} $N \subseteq X$.
 	\end{center}

--- a/content/sets-functions-relations/infinite/dedekind-induction.tex
+++ b/content/sets-functions-relations/infinite/dedekind-induction.tex
@@ -19,7 +19,7 @@ any formula $\phi(x, \overline{v})$ and any sets
 $\overline{c}$:\footnote{This may be new notation for you. We write
 $\phi(x, v_1, \ldots, v_n)$ as $\phi(x, \overline{v})$; and if we have
 sets $c_1, \ldots, c_n$, we can write $\phi(x, \overline{c})$ in place
-of $\phi(x, v_1, \ldots, v_n)$.} 
+of $\phi(x, c_1, \ldots, c_n)$.} 
 	\begin{center}
 		if $o \in X$ and $(\forall {n} \in N \cap X){s}({n}) \in X$, {then} $N \subseteq X$.
 	\end{center}


### PR DESCRIPTION
Fixes a small typo in a footnote defining "vector" notation for parameters in a formula