### PR TITLE
Possible typo in primitive-recursion.tex

### DIFF
--- a/content/computability/recursive-functions/primitive-recursion.tex
+++ b/content/computability/recursive-functions/primitive-recursion.tex
@@ -99,7 +99,7 @@ $\Mult(2,1)$, $\Mult(2,2)$, and~$\Mult(2,3)$:
 The general pattern then is this: to give a primitive recursive
 definition of a function~$h(x_0, \dots, x_{k-1}, y)$, we provide two
 equations. The first defines the value of $h(x_0, \dots, x_{k-1}, 0)$
-without reference to~$f$. The second defines the value of $h(x_0,
+without reference to~$h$. The second defines the value of $h(x_0,
 \dots, x_{k-1}, y+1)$ in terms of $h(x_0, \dots, x_{k-1}, y)$, the other
 arguments $x_0$, \dots,~$x_{k-1}$, and~$y$. Only the immediately preceding
 value of~$h$ may be used in that second equation.  If we think of the


### PR DESCRIPTION
The current passage from lines 99 to 102 reads as follows:


> The general pattern then is this: to give a primitive recursive definition of a function <img src="https://render.githubusercontent.com/render/math?math=h(x_0, \dotsc, x_{k-1}, y)">, we provide two equations. The first defines the value of  <img src="https://render.githubusercontent.com/render/math?math=h(x_0, \dotsc, x_{k-1}, 0)"> without reference to <img src="https://render.githubusercontent.com/render/math?math=f">.


It seems like the reference to <img src="https://render.githubusercontent.com/render/math?math=f"> might be a typo or ambiguous, since <img src="https://render.githubusercontent.com/render/math?math=f"> is last mentioned on line 50. The passage seems to make more sense if it were to say that the initial value of <img src="https://render.githubusercontent.com/render/math?math=h"> is defined without reference to itself, instead of defined without reference to <img src="https://render.githubusercontent.com/render/math?math=f">.