### PR TITLE
customizable syntax for assignement variants

### DIFF
--- a/content/first-order-logic/axiomatic-deduction/soundness.tex
+++ b/content/first-order-logic/axiomatic-deduction/soundness.tex
@@ -43,7 +43,7 @@ utmost importance.
   instance, here is the case for \olref[qua]{ax:q1}: suppose $t$ is
   !!{free for} $x$ in $!A$, and assume
   $\Sat{M}{\lforall[x][!A]}[s]$. Then by definition of satisfaction,
-  for each $s' \sim_x s$, also $\Sat{M}{!A}[s']$, and in particular
+  for each $\varAssign{s'}{s}{x}$, also $\Sat{M}{!A}[s']$, and in particular
   this holds when $s'(x) = \Value{t}{M}[s]$. By
   \olref[syn][ext]{prop:ext-formulas},
   $\Sat{M}{\Subst{!A}{t}{x}}[s]$. This shows that

--- a/content/first-order-logic/sequent-calculus/soundness-identity.tex
+++ b/content/first-order-logic/sequent-calculus/soundness-identity.tex
@@ -32,7 +32,7 @@ $\Sat{M}{\eq[t_1][t_2]}$ and $\Sat{M}{\Gamma}$ either (a) for some $!C
 \in \Delta$, $\Sat{M}{!C}$ or (b) $\Sat{M}{!A(t_1)}$. In case (a) we
 are done. Consider case (b).  Let $s$ be a variable assignment with
 $s(x) = \Value{t_1}{M}$.  By \olref[syn][ass]{prop:sentence-sat-true},
-$\Sat{M}{!A(t_1)}[s]$. Since $s \sim_x s$, by
+$\Sat{M}{!A(t_1)}[s]$. Since $\varAssign{s}{s}{x}$, by
 \olref[syn][ext]{prop:ext-formulas}, $\Sat{M}{!A(x)}[s]$. since
 $\Sat{M}{\eq[t_1][t_2]}$, we have $\Value{t_1}{M} = \Value{t_2}{M}$,
 and hence $s(x) = \Value{t_2}{M}$.  By applying

--- a/content/first-order-logic/sequent-calculus/soundness.tex
+++ b/content/first-order-logic/sequent-calculus/soundness.tex
@@ -255,7 +255,7 @@ First, we consider the possible inferences with only one premise.
   $\Sat{M'}{!C}$ since $a$ does not occur in~$\Gamma$, and for any
   $!C \in \Delta$, $\Sat/{M'}{!C}$. But the premise is valid, so
   $\Sat{M'}{!A(a)}$. By \olref[syn][ass]{prop:sentence-sat-true},
-  $\Sat{M'}{!A(a)}[s]$, since $!A(a)$ is a sentence. Now $s \sim_x s$
+  $\Sat{M'}{!A(a)}[s]$, since $!A(a)$ is a sentence. Now $\varAssign{s}{s}{x}$
   with $s(x) = \Value{a}{M'}[s]$, since we've defined $\Struct{M'}$ in
   just this way. So \olref[syn][ext]{prop:ext-formulas} applies, and
   we get $\Sat{M'}{!A(x)}[s]$. Since $a$ does not occur in~$!A(x)$, by

--- a/content/first-order-logic/syntax-and-semantics/extensionality.tex
+++ b/content/first-order-logic/syntax-and-semantics/extensionality.tex
@@ -63,7 +63,7 @@ satisfies !!a{formula}, only depends on the values of its subterms.
 
 \begin{prop}\ollabel{prop:ext-terms}
 Let $\Struct M$ be a !!{structure}, $t$ and $t'$ terms, and $s$ a
-variable assignment. Let $s' \sim_x s$ be the $x$-variant of~$s$ given
+variable assignment. Let $\varAssign{s'}{s}{x}$ be the $x$-variant of~$s$ given
 by~$s'(x) = \Value{t'}{M}[s]$. Then $\Value{\Subst{t}{t'}{x}}{M}[s] =
 \Value{t}{M}[s']$.
 \end{prop}
@@ -76,7 +76,7 @@ By induction on~$t$.
 
 \item If $t$ is a variable other than~$x$, say, $t \ident y$, then
   $\Subst{t}{t'}{x} = y$, and $\Value{y}{M}[s] = \Value{y}{M}[s']$
-  since $s' \sim_x s$.
+  since $\varAssign{s'}{s}{x}$.
 
 \item If $t \ident x$, then $\Subst{t}{t'}{x} = t'$. But
   $\Value{x}{M}[s'] = \Value{t'}{M}[s]$ by definition of~$s'$.
@@ -102,7 +102,7 @@ By induction on~$t$.
 
 \begin{prop}\ollabel{prop:ext-formulas}
 Let $\Struct M$ be a !!{structure}, $!A$ !!a{formula}, $t$ a term,
-and $s$ a variable assignment. Let $s' \sim_x s$ be the $x$-variant of
+and $s$ a variable assignment. Let $\varAssign{s'}{s}{x}$ be the $x$-variant of
 $s$ given by~$s'(x) = \Value{t}{M}[s]$. Then
 $\Sat{M}{\Subst{!A}{t}{x}}[s]$ iff $\Sat{M}{!A}[s']$.
 \end{prop}

--- a/content/first-order-logic/syntax-and-semantics/satisfaction.tex
+++ b/content/first-order-logic/syntax-and-semantics/satisfaction.tex
@@ -310,7 +310,7 @@ On the other hand,
 The only $x$-variants~$s_i$ of $s$ with $\Sat{M}{R(a,x)}[s_i]$ are
 $s_1$ and~$s_2$. But for each, there is in turn a $y$-variant 
 $\varAssign{s_i'}{s_i}{y}$ with $s_i'(y) = 4$ so that $\Sat/{M}{R(x,y)}[s_i']$ 
-and so$\Sat/{M}{\lforall[y][R(x,y)]}[s_i]$ for $i = 1$, $2$. In sum, 
+and so $\Sat/{M}{\lforall[y][R(x,y)]}[s_i]$ for $i = 1$, $2$. In sum, 
 none of the $x$-variants~$\varAssign{s_i}{s}{x}$ are such that $\Sat{M}{R(a,x) \land
   \lforall[y][R(x,y)]}[s_i]$.
 \end{ex}

--- a/content/first-order-logic/syntax-and-semantics/satisfaction.tex
+++ b/content/first-order-logic/syntax-and-semantics/satisfaction.tex
@@ -73,7 +73,7 @@ follows:
 If $s$ is a !!{variable} assignment for a !!{structure}~$\Struct M$, then any
 !!{variable} assignment $s'$ for $\Struct M$ which differs from $s$ at most
 in what it assigns to $x$ is called an \emph{$x$-variant} of~$s$.  If
-$s'$ is an $x$-variant of $s$ we write $s \sim_x s'$.
+$s'$ is an $x$-variant of $s$ we write $\varAssign{s'}{s}{x}$.
 \end{defn}
 
 \begin{explain}
@@ -295,7 +295,7 @@ $\tuple{1,1} \in \Assign{R}{M}$), so the answer is yes. To determine
 if $\Sat{M}{\lexists[y][R(x,y)]}[s_2]$ we have to look at the
 $y$-variants of~$s_2$. Here, $s_2$ itself does not satisfy $R(x,y)$
 ($s_2(x) = 2$, $s_2(y) = 1$, and $\tuple{2,1}\notin
-\Assign{R}{M}$). However, consider $s_2' \sim_y s_2$ with $s_2'(y) =
+\Assign{R}{M}$). However, consider $\varAssign{s_2'}{s_2}{y}$ with $s_2'(y) =
 3$. $\Sat{M}{R(x,y)}[s_2']$ since $\tuple{2,3} \in \Assign{R}{M}$, and
 so $\Sat{M}{\lexists[y][R(x,y)]}[s_2]$. In sum, for every
 $x$-variant~$s_i$ of $s$, either $\Sat/{M}{R(a,x)}[s_i]$ ($i = 3$,
@@ -308,10 +308,10 @@ On the other hand,
 \Sat/{M}{\lexists[x][(R(a,x) \land \lforall[y][R(x,y)])]}[s].
 \]
 The only $x$-variants~$s_i$ of $s$ with $\Sat{M}{R(a,x)}[s_i]$ are
-$s_1$ and~$s_2$. But for each, there is in turn a $y$-variant $s_i'
-\sim_y s_i$ with $s_i'(y) = 4$ so that $\Sat/{M}{R(x,y)}[s_i']$ and so
-$\Sat/{M}{\lforall[y][R(x,y)]}[s_i]$ for $i = 1$, $2$. In sum, none of the
-$x$-variants~$s_i \sim_x s$ are such that $\Sat{M}{R(a,x) \land
+$s_1$ and~$s_2$. But for each, there is in turn a $y$-variant 
+$\varAssign{s_i'}{s_i}{y}$ with $s_i'(y) = 4$ so that $\Sat/{M}{R(x,y)}[s_i']$ 
+and so$\Sat/{M}{\lforall[y][R(x,y)]}[s_i]$ for $i = 1$, $2$. In sum, 
+none of the $x$-variants~$\varAssign{s_i}{s}{x}$ are such that $\Sat{M}{R(a,x) \land
   \lforall[y][R(x,y)]}[s_i]$.
 \end{ex}
 

--- a/content/first-order-logic/tableaux/soundness-identity.tex
+++ b/content/first-order-logic/tableaux/soundness-identity.tex
@@ -33,7 +33,7 @@ both~$\sFmla{\True}{\eq[t_1][t_2]}$ and $\sFmla{\True}{!A(t_1)}$. Thus
 we have $\Sat{M}{\eq[t_1][t_2]}$ and $\Sat{M}{!A(t_1)}$. Let $s$ be a
 variable assignment with $s(x) = \Value{t_1}{M}$.  By
 \olref[syn][ass]{prop:sentence-sat-true}, $\Sat{M}{!A(t_1)}[s]$. Since
-$s \sim_x s$, by \olref[syn][ext]{prop:ext-formulas},
+$\varAssign{s}{s}{x}$, by \olref[syn][ext]{prop:ext-formulas},
 $\Sat{M}{!A(x)}[s]$. since $\Sat{M}{\eq[t_1][t_2]}$, we have
 $\Value{t_1}{M} = \Value{t_2}{M}$, and hence $s(x) = \Value{t_2}{M}$.
 By applying \olref[syn][ext]{prop:ext-formulas} again, we also have

--- a/content/second-order-logic/syntax-and-semantics/inf-count.tex
+++ b/content/second-order-logic/syntax-and-semantics/inf-count.tex
@@ -90,10 +90,10 @@ $s(u) = f$. We show that
 \Sat{M}{\lforall[X][((X(z) \land \lforall[x][(X(x) \lif X(u(x)))])
     \lif \lforall[x][X(x)])]}[s]
 \]
-Suppose $s' \sim_X s$ is arbitrary, and let $M = s'(X)$. Suppose
+Suppose $\varAssign{s'}{s}{X}$ is arbitrary, and let $M = s'(X)$. Suppose
 further that $\Sat{M}{(X(z) \land \lforall[x][(X(x) \lif
     X(u(x)))])}[s']$. Then $s'(z) \in M$ and whenever $x \in M$, also
-$s'(u)(x) \in M$. In other words, since $s' \sim_X s$, $m_0 \in M$ and
+$s'(u)(x) \in M$. In other words, since $\varAssign{s'}{s}{X}$, $m_0 \in M$ and
 if $x \in M$ then $f(x) \in M$, so $m_0 \in M$, $m_1 = f(m_0) \in M$,
 $m_2 = f(f(m_0)) \in M$, etc. Thus, $M = \Domain{M}$, and so
 $\Sat{M}{\lforall[x][X(x)]}[s']$. Since $s'$ was an arbitrary

--- a/content/second-order-logic/syntax-and-semantics/satisfaction.tex
+++ b/content/second-order-logic/syntax-and-semantics/satisfaction.tex
@@ -59,7 +59,7 @@ If $s$ is !!a{variable} assignment for !!a{structure}~$\Struct M$,
 then any !!{variable} assignment $s'$ for $\Struct M$ which differs
 from $s$ at most in what it assigns to $x$ is called an
 \emph{$x$-variant} of~$s$.  If $s'$ is an $x$-variant of $s$ we write
-$s \sim_x s'$. (Similarly for second-order variables $X$ or $u$.)
+$\varAssign{s'}{s}{x}$. (Similarly for second-order variables $X$ or $u$.)
 \end{defn}
 
 
@@ -126,7 +126,7 @@ like \olref[fol][syn][sat]{defn:satisfaction} with the addition of:
 \begin{ex}
 $\Sat{M}{\lexists[Y][(\lexists[y][\Atom{Y}{y}] \land
       \lforall[z][(\Atom{X}{z} \liff \lnot \Atom{Y}{z})])]}[s]$ if
-  there is an $s' \sim_Y s$ such that
+  there is an $\varAssign{s'}{s}{Y}$ such that
   $\Sat{M}{(\lexists[y][\Atom{Y}{y}] \land \lforall[z][(\Atom{X}{z}
       \liff \lnot \Atom{Y}{z})])}[s']$. And that is the case iff $s'(Y)
   \neq \emptyset$ (so that $\Sat{M}{\lexists[y][\Atom{Y}{y}]}[s']$)

--- a/open-logic-config.sty
+++ b/open-logic-config.sty
@@ -406,14 +406,14 @@
 % - `\varAssign{s'}{s}{x}[o]` - Assignment variant. Takes three mandatory
 % argument (s' differs from s at most at x) and one optional one (s' assigns
 % o to x. Default: `\varAssign{s'}{s}{x}` produces `s' \sim_{x} s`
-% and `\varAssign{s'}{s}{x}[o] produces `s' = s^{x}_{o}`.
+% and `\varAssign{s'}{s}{x}[o] produces `s' = s[o/x]`.
 
 \DeclareDocumentCommand \varAssign { m m m o } {
     \IfNoValueTF {#4}
         % optional argument not present
         { #1 \sim_{#3} #2 }
         % optional argument present
-        { #1 = #2^{#3}_{#4} }
+        { #1 = #2\[^{#4}/{#3}\] }
 }
 
 % - `\Value{t}{M}[s]` - Value of a term in a structure. Takes two mandatory

--- a/open-logic-config.sty
+++ b/open-logic-config.sty
@@ -411,7 +411,7 @@
 \DeclareDocumentCommand \varAssign { m m m o } {
     \IfNoValueTF {#4}
         % optional argument not present
-        { #1 \sim{#3} #2 }
+        { #1 \sim_{#3} #2 }
         % optional argument present
         { #1 = #2^{#3}_{#4} }
 }

--- a/open-logic-config.sty
+++ b/open-logic-config.sty
@@ -403,6 +403,19 @@
 
 \DeclareDocumentCommand \Assign { m m }{\mathord{#1^{\Struct{#2}}}}
 
+% - `\varAssign{s'}{s}{x}[o]` - Assignment variant. Takes three mandatory
+% argument (s' differs from s at most at x) and one optional one (s' assigns
+% o to x. Default: `\varAssign{s'}{s}{x}` produces `s' \sim_{x} s`
+% and `\varAssign{s'}{s}{x}[o] produces `s' = s^{x}_{o}`.
+
+\DeclareDocumentCommand \varAssign { m m m o } {
+    \IfNoValueTF {#4}
+        % optional argument not present
+        { #1 \sim{#3} #2 }
+        % optional argument present
+        { #1 = #2^{#3}_{#4} }
+}
+
 % - `\Value{t}{M}[s]` - Value of a term in a structure. Takes two mandatory
 % arguments (term and structure) and one optional argument (variable
 % assignment). By default, `\Value{t}{M}[s]` produces 


### PR DESCRIPTION
Currently assignment variants are hardcoded as `\sim`, e.g. `$s \sim_x s'`. This is not ideal when we also use `\sim` for negation. This PR introduces a customizable syntax and implements it throughout the OLP (all occurrences of \sim have been checked). The proposed syntax is:

`\varAssign{s'}{s}{x}[o]`

- three arguments: "`s'` differs from `s` at most at `x`".
- four arguments: "`s'` differs from `s` at most at `x` and assigns `o` to `x`". (Not used in the book so far.)

The defaults produce `s' \sim_{x} s` and `s' = s^{o}_{x}`, respectively:

```
\DeclareDocumentCommand \varAssign { m m m o } {
    \IfNoValueTF {#4}
        % optional argument not present
        { #1 \sim_{#3} #2 }
        % optional argument present
        { #1 = #2^{#3}_{#4} }
}
```