### PR TITLE
Correct possible typo in Problem 1.4

### DIFF
--- a/content/normal-modal-logic/syntax-and-semantics/truth-at-w.tex
+++ b/content/normal-modal-logic/syntax-and-semantics/truth-at-w.tex
@@ -40,7 +40,7 @@ usual characterization using truth tables for the non-modal operators.
   \item\ollabel{defn:sub:mmodels-diamond}
     \indcase{!A}{\Diamond !B}{$\mSat{M}{\indfrm}[w]$ iff
     $\mSat{M}{!B}[w']$ for at least one $w' \in W$ with $Rww'$}
-  \end{enumerate} 
+  \end{enumerate}
 \end{defn}
 
 Note that by clause~\olref{defn:sub:mmodels-box}, !!a{formula}~$\Box
@@ -64,7 +64,7 @@ for any~$!A$.
     \item $\mSat{M}{\Box \bot}[w_3]$;
     \item $\mSat{M}{\Diamond q}[w_1]$;
     \item $\mSat{M}{\Box q}[w_1]$;
-    \item $\mSat{M}{\lnot \Box\Box \lnot q}[w_1]$. 
+    \item $\mSat{M}{\lnot \Box\Box \lnot q}[w_1]$.
     \end{enumerate}
 \end{prob}
 
@@ -118,7 +118,7 @@ for any~$!A$.
 \end{prob}
 
 \begin{probtag}{prvDiamond}
-  Let $\mModel{M} = \tuple{M, R, V}$. Show that
+  Let $\mModel{M} = \tuple{W, R, V}$. Show that
   $\mSat{M}{\lnot\Diamond !A}[w]$ if and only if
   $\mSat{M}{\Box\lnot!A}[w]$.
 \end{probtag}


### PR DESCRIPTION
Changes the model _M=<**M**,R,V>_ to _M=<**W**,R,V>_ in Problem 1.4 of Syntax and semantics. (Some trailing whitespace was removed in the process.)