### PR TITLE
minor typo in tableau rules for identity

### DIFF
--- a/content/first-order-logic/tableaux/identity.tex
+++ b/content/first-order-logic/tableaux/identity.tex
@@ -29,7 +29,7 @@ The rules for $\eq$ are ($t$, $t_1$, and $t_2$ are closed terms):
 \AxiomC{\sFmla{\True}{\eq[t_1][t_2]}}
 \noLine
 \UnaryInfC{\sFmla{\False}{!A(t_1)}}
-\RightLabel{$\TRule{\True}{\eq}$}
+\RightLabel{$\TRule{\False}{\eq}$}
 \UnaryInfC{\sFmla{\False}{!A(t_1)}}
 \DisplayProof
 \end{defish}


### PR DESCRIPTION
The third rule for identity should be labelled `\False\eq`