### PR TITLE
Correct possible typo in proof of 1.22

### DIFF
--- a/content/normal-modal-logic/syntax-and-semantics/schemas.tex
+++ b/content/normal-modal-logic/syntax-and-semantics/schemas.tex
@@ -34,7 +34,7 @@ to the characteristic !!{formula}s $p$, $p \lif \Box p$, $p \lif (q
 \begin{defn}
   A schema is \emph{true} in a model if and only if all of its instances
   are; and a schema is \emph{valid} if and only if it is true in every
-  model. 
+  model.
 \end{defn}
 
 \begin{prop}\ollabel{prop:Kvalid}
@@ -92,7 +92,7 @@ to the characteristic !!{formula}s $p$, $p \lif \Box p$, $p \lif (q
   $\mModel{M} = \tuple{W, R, V}$ is a modal model, and $!B \ident
   \SSubst{!A}{\subst{!D_1}{p_1},\dots,\subst{!D_n}{p_n}}$ is a
   substitution instance of~$!A$. Define $\mModel{M'} = \tuple{W, R,
-    V'}$ by $V(p_i) = \Setabs{w}{\mSat{M}{!D_i}[w]}$.  Then
+    V'}$ by $V'(p_i) = \Setabs{w}{\mSat{M}{!D_i}[w]}$.  Then
   $\mSat{M}{!B}[w]$ iff $\mSat{M'}{!A}[w]$, for any~$w \in W$. (We
   leave the proof as an exercise.) Now suppose that $!A$ was valid,
   but some substitution instance $!B$ of~$!A$ was not valid. Then for
@@ -137,12 +137,12 @@ at~$w$. But $\lfalse$ is an instance of~$p$, and not true at~$w$.
       $\Box(!A \lif !B) \lif (\Diamond !A \lif \Diamond !B)$
       & $\Box (!A \lor !B) \lif (\Box !A \lor \Box !B)$ \\
       $\Diamond (!A \lif !B) \lif (\Box !A \lif \Diamond
-      !B)$ 
+      !B)$
       & $(\Diamond !A \land \Diamond !B) \lif \Diamond (!A
       \land !B)$\\
       $\Box (!A \land !B) \liff (\Box !A \land \Box !B)$
       & $!A \lif \Box !A$ \\
-      $\Box !A \lif \Box (!B \lif !A)$ 
+      $\Box !A \lif \Box (!B \lif !A)$
       & $\Box \Diamond !A \lif !B$ \\
       $\lnot \Diamond !A \lif \Box (!A \lif !B)$
       & $\Box \Box !A \lif \Box !A$ \\


### PR DESCRIPTION
The model _M'_ is _M'=<W,R,V'>_ but un-primed _V_ is used in its definition.