### PR TITLE
minor typo

### DIFF
--- a/content/first-order-logic/tableaux/proving-things-quant.tex
+++ b/content/first-order-logic/tableaux/proving-things-quant.tex
@@ -29,7 +29,7 @@ $\TRule{\False}{\lif}$:
 \begin{oltableau}
 [\sFmla{\False}{\lexists[x][\lnot \formula{A}(x)]\lif \lnot
     \lforall[x][\formula{A}(x)]}, just=\TAss, checked
-  [\sFmla{\False}{\lexists[x][\lnot \formula{A}(x)]},
+  [\sFmla{\True}{\lexists[x][\lnot \formula{A}(x)]},
     just={\TRule{\False}{\lif}[1]}
     [\sFmla{\False}{\lnot\lforall[x][\formula{A}(x)]},
       just={\TRule{\False}{\lif}[1]}]


### PR DESCRIPTION
Developing F-> should be T antecedent, as in the more developped version of that tableau below.