### PR TITLE
Fix three typos in text

### DIFF
--- a/content/normal-modal-logic/syntax-and-semantics/introduction.tex
+++ b/content/normal-modal-logic/syntax-and-semantics/introduction.tex
@@ -39,7 +39,7 @@ implication by means of the material conditional: $!A \lif !B$
 is a poor substitute for ``$!A$ implies $!B$.'' Instead, they
 proposed to characterize implication as ``Necessarily, if $!A$
 then $!B$,'' symbolized as $!A \strictif !B$. In trying to
-sort out the different properties, Lewis indentified five different
+sort out the different properties, Lewis identified five different
 modal systems, \Log{S1}, \ldots, \Log{S4}, \Log{S5}, the last
 two of which are still in use.
 
@@ -79,7 +79,7 @@ relational structures come in all sorts of domains: besides relative
 possibility of states of the world, we can have epistemic states of
 some agent related by epistemic possibility, or states of a dynamical
 system with their state transitions, etc. Modal logic can be used to
-model all of these: the first give us ordinary, alethic, modal logic;
+model all of these: the first gives us ordinary, alethic, modal logic;
 the others give us epistemic logic, dynamic logic, etc.
 
 We focus on one particular angle, known to modal logicians as

--- a/content/normal-modal-logic/syntax-and-semantics/truth-at-w.tex
+++ b/content/normal-modal-logic/syntax-and-semantics/truth-at-w.tex
@@ -44,7 +44,7 @@ usual characterization using truth tables for the non-modal operators.
 \end{defn}
 
 Note that by clause~\olref{defn:sub:mmodels-box}, !!a{formula}~$\Box
-!B$ is true at~$w$ whenever there are no~$w'$ with $wRw'$. In
+!B$ is true at~$w$ whenever there are no~$w'$ with $Rww'$. In
 such a case $\Box !B$ is \emph{vacuously} true at~$w$. Also,
 $\Box !B$ may be satisfied at~$w$ even if $!B$ is not. The truth
 of~$!B$ at~$w$ does not guarantee the truth of~$\Diamond !B$


### PR DESCRIPTION
Please accept these small changes:

The first two are actual grammar typos. The last one regards notation
consistency: "wRw'" -> "Rww'" (I think the latter is more appropriate
since consistent with the notation used in the rest of the chapter).