### PR TITLE
Fix typo in proof of Lindenbaum's Lemma

### DIFF
--- a/content/normal-modal-logic/completeness/lindenbaums-lemma.tex
+++ b/content/normal-modal-logic/completeness/lindenbaums-lemma.tex
@@ -66,7 +66,7 @@ are $\Sigma$-consistent.
 So suppose $\Delta$ were $\Sigma$-inconsistent. Then $\Delta
 \Proves[\Sigma] \lfalse$, i.e., there are $!A_1$, \dots,~$!A_k \in
 \Delta$ such that $\Sigma \Proves !A_1 \lif (!A_2 \lif \cdots (!A_k
-\lif \lfalse)\dots)$. Since $\Delta = \bigcap_{n=0}^\infty$, each
+\lif \lfalse)\dots)$. Since $\Delta = \bigcup_{n=0}^\infty$, each
 $!A_i \in \Delta_{n_i}$ for some~$n_i$. Let $n$ be the largest of
 these. Since $n_i \le n$, $\Delta_{n_i} \subseteq \Delta_n$. So, all
 $!A_i$ are in some~$\Delta_n$. This would mean $\Delta_n

--- a/content/normal-modal-logic/completeness/lindenbaums-lemma.tex
+++ b/content/normal-modal-logic/completeness/lindenbaums-lemma.tex
@@ -40,7 +40,7 @@ defined, we define $\Delta_{n+1}$ by:
   \Delta_n \cup \{ \lnot !A_n\}, & \text{otherwise.}
 \end{cases}
 \]
-If we now let $\Delta = \bigcup_{n=0}^\infty \Delta_n$.
+Now let $\Delta = \bigcup_{n=0}^\infty \Delta_n$.
 
 We have to show that this definition actually yields a set $\Delta$
 with the required properties, i.e., $\Gamma \subseteq \Delta$ and
@@ -66,7 +66,7 @@ are $\Sigma$-consistent.
 So suppose $\Delta$ were $\Sigma$-inconsistent. Then $\Delta
 \Proves[\Sigma] \lfalse$, i.e., there are $!A_1$, \dots,~$!A_k \in
 \Delta$ such that $\Sigma \Proves !A_1 \lif (!A_2 \lif \cdots (!A_k
-\lif \lfalse)\dots)$. Since $\Delta = \bigcup_{n=0}^\infty$, each
+\lif \lfalse)\dots)$. Since $\Delta = \bigcup_{n=0}^\infty \Delta_n$, each
 $!A_i \in \Delta_{n_i}$ for some~$n_i$. Let $n$ be the largest of
 these. Since $n_i \le n$, $\Delta_{n_i} \subseteq \Delta_n$. So, all
 $!A_i$ are in some~$\Delta_n$. This would mean $\Delta_n


### PR DESCRIPTION
The set \Delta is constructed from the *union* of all \Delta_n. Not from
the intersection.