### PR TITLE
Fix some typos and duplicate exercises in the modal logic chapters

### DIFF
--- a/content/normal-modal-logic/completeness/completeness-K.tex
+++ b/content/normal-modal-logic/completeness/completeness-K.tex
@@ -12,7 +12,7 @@
 
 We are now prepared to use the canonical model to establish
 completeness. Completeness follows from the fact that the !!{formula}s
-true in the canonical for~$\Sigma$ are exactly the
+true in the canonical model for~$\Sigma$ are exactly the
 $\Sigma$-!!{derivable} ones. Models with this property are said to
 \emph{determine}~$\Sigma$.
 

--- a/content/normal-modal-logic/completeness/lindenbaums-lemma.tex
+++ b/content/normal-modal-logic/completeness/lindenbaums-lemma.tex
@@ -62,7 +62,7 @@ Finally, we have to show, that $\Delta$ is $\Sigma$-consistent.  To do
 this, we show that (a) if $\Delta$ were $\Sigma$-inconsistent, then
 some $\Delta_n$ would be $\Sigma$-inconsistent, and (b) all $\Delta_n$
 are $\Sigma$-consistent.
-  
+
 So suppose $\Delta$ were $\Sigma$-inconsistent. Then $\Delta
 \Proves[\Sigma] \lfalse$, i.e., there are $!A_1$, \dots,~$!A_k \in
 \Delta$ such that $\Sigma \Proves !A_1 \lif (!A_2 \lif \cdots (!A_k
@@ -76,7 +76,7 @@ To show that each $\Delta_n$ is $\Sigma$-consistent, we use a simple
 induction on~$n$. $\Delta_0 = \Gamma$, and we assumed $\Gamma$ was
 $\Sigma$-consistent. So the claim holds for $n = 0$. Now suppose it
 holds for $n$, i.e., $\Delta_n$ is $\Sigma$-consistent. $\Delta_{n+1}$
-is either $\Delta_n \cup \{!A_n\}$ is that is $\Sigma$-consistent,
+is either $\Delta_n \cup \{!A_n\}$ if that is $\Sigma$-consistent,
 otherwise it is $\Delta_n \cup \{\lnot!A_n\}$. In the first case,
 $\Delta_{n+1}$ is clearly $\Sigma$-consistent. However, by
 \olref[prf][con]{prop:consistencyfacts}\olref[prf][con]{prop:consistencyfacts-c},

--- a/content/normal-modal-logic/filtrations/S5-decidable.tex
+++ b/content/normal-modal-logic/filtrations/S5-decidable.tex
@@ -11,7 +11,7 @@
 \olsection{\Log{S5} is Decidable}
 The finite model property gives us an easy way to show that systems of
 modal logic given by schemas are \emph{decidable} (i.e., that there is
-a computable procedure to determine whether !!a{formula}s is !!{derivable} in
+a computable procedure to determine whether !!a{formula} is !!{derivable} in
 the system or not).
 
 \begin{thm}
@@ -34,15 +34,5 @@ the system or not).
 The above proof works for \Log{S5} because filtrations of universal
 models are automatically universal. The same holds for reflexivity and
 seriality, but more work is needed for other properties.
-
-\begin{prob}
-  Show that any filtration of a serial or reflexive model is also
-  serial or reflexive (respectively).
-\end{prob}
-
-\begin{prob}
-  Find a non-symmetric (non-transitive, non-euclidean) filtration of a
-  symmetric (transitive, euclidean) model.
-\end{prob}
 
 \end{document}

--- a/content/normal-modal-logic/tableaux/completeness.tex
+++ b/content/normal-modal-logic/tableaux/completeness.tex
@@ -7,7 +7,7 @@
 \begin{document}
 
 \olfileid{nml}{tab}{cpl}
-      
+
 \olsection{Completeness for \Log{K}}
 
 \begin{explain}
@@ -129,7 +129,7 @@ $\mSat/{M(\Delta)}{!A}[\sigma]$.
       complete. By induction hypothesis,
       $\mSat{M(\Delta)}{!B}[\sigma]$ and thus
       $\mSat/{M(\Delta)}{\indfrm}[\sigma]$.}}
-  \item \indcase{!A}{!B \land !A}{\iftag{probAnd}{Exercise.}{If
+  \item \indcase{!A}{!B \land !C}{\iftag{probAnd}{Exercise.}{If
       $\sFmla{\True}{\indfrm}[\sigma] \in \Delta$, then both
       $\sFmla{\True}{!B}[\sigma] \in \Delta$ and
       $\sFmla{\True}{!C}[\sigma] \in \Delta$ since the branch is
@@ -145,7 +145,7 @@ $\mSat/{M(\Delta)}{!A}[\sigma]$.
       $\mSat/{M(\Delta)}{!B}[\sigma]$ or
       $\mSat/{M(\Delta)}{!B}[\sigma]$. Thus
       $\mSat/{M(\Delta)}{\indfrm}[\sigma]$.}}
-  \item \indcase{!A}{!B \lor !A}{\iftag{probOr}{Exercise.}{If
+  \item \indcase{!A}{!B \lor !C}{\iftag{probOr}{Exercise.}{If
       $\sFmla{\True}{\indfrm}[\sigma] \in \Delta$, then either
       $\sFmla{\True}{!B}[\sigma] \in \Delta$ or
       $\sFmla{\True}{!C}[\sigma] \in \Delta$ since the branch is
@@ -161,7 +161,7 @@ $\mSat/{M(\Delta)}{!A}[\sigma]$.
       $\mSat/{M(\Delta)}{!B}[\sigma]$ and
       $\mSat/{M(\Delta)}{!B}[\sigma]$. Thus
       $\mSat/{M(\Delta)}{\indfrm}[\sigma]$.}}
-  \item \indcase{!A}{!B \lif !A}{\iftag{probIf}{Exercise.}{If
+  \item \indcase{!A}{!B \lif !C}{\iftag{probIf}{Exercise.}{If
       $\sFmla{\True}{\indfrm}[\sigma] \in \Delta$, then either
       $\sFmla{\False}{!B}[\sigma] \in \Delta$ or
       $\sFmla{\True}{!C}[\sigma] \in \Delta$ since the branch is

--- a/content/normal-modal-logic/tableaux/proofs-in-K.tex
+++ b/content/normal-modal-logic/tableaux/proofs-in-K.tex
@@ -20,20 +20,20 @@
         \Box (\formula{A} \land \formula{B})}{1},
       just =\TAss
       [\pFmla{\True}{\Box\formula{A} \land \Box\formula{B}}{1},
-        just = {\TRule{\True}{\lif}[1]}
+        just = {\TRule{\False}{\lif}[1]}
         [\pFmla{\False}{\Box(\formula{A} \land \formula{B})}{1},
-          just = {\TRule{\True}{\lif}[1]}
+          just = {\TRule{\False}{\lif}[1]}
           [\pFmla{\True}{\Box\formula{A}}{1},
             just = {\TRule{\True}{\land}[2]}
             [\pFmla{\True}{\Box\formula{B}}{1},
               just = {\TRule{\True}{\land}[2]}
               [\pFmla{\False}{\formula{A} \land \formula{B}}{1.1},
                 just = {\TRule{\False}{\Box}[3]}
-                [\pFmla{\False}{\formula{A}}{1.1}, 
+                [\pFmla{\False}{\formula{A}}{1.1},
                   just = {\TRule{\False}{\land}[6]}
                   [\pFmla{\True}{\formula{A}}{1.1},
                     just= {\TRule{\True}{\Box}[4]}, close]]
-                [\pFmla{\False}{\formula{B}}{1.1}, 
+                [\pFmla{\False}{\formula{B}}{1.1},
                   just = {\TRule{\False}{\land}[6]}
                   [\pFmla{\True}{\formula{B}}{1.1},
                     just= {\TRule{\True}{\Box}[5]}, close]]
@@ -56,20 +56,20 @@
         (\Diamond \formula{A} \lor \Diamond \formula{B})}{1},
       just =\TAss
       [\pFmla{\True}{\Diamond(\formula{A} \lor \formula{B})}{1},
-        just = {\TRule{\True}{\lif}[1]}
+        just = {\TRule{\False}{\lif}[1]}
         [\pFmla{\False}{\Diamond\formula{A} \lor \Diamond\formula{B}}{1},
-          just = {\TRule{\True}{\lif}[1]}
+          just = {\TRule{\False}{\lif}[1]}
           [\pFmla{\False}{\Diamond\formula{A}}{1},
             just = {\TRule{\False}{\lor}[3]}
             [\pFmla{\False}{\Diamond\formula{B}}{1},
               just = {\TRule{\False}{\lor}[3]}
               [\pFmla{\True}{\formula{A} \lor \formula{B}}{1.1},
                 just = {\TRule{\True}{\Diamond}[2]},
-                [\pFmla{\True}{\formula{A}}{1.1}, 
+                [\pFmla{\True}{\formula{A}}{1.1},
                   just = {\TRule{\True}{\lor}[6]}
                   [\pFmla{\False}{\formula{A}}{1.1},
                     just= {\TRule{\False}{\Diamond}[4]}, close]]
-                [\pFmla{\True}{\formula{B}}{1.1}, 
+                [\pFmla{\True}{\formula{B}}{1.1},
                   just = {\TRule{\True}{\lor}[6]}
                   [\pFmla{\False}{\formula{B}}{1.1},
                     just= {\TRule{\False}{\Diamond}[5]}, close]]

--- a/content/normal-modal-logic/tableaux/rules-for-K.tex
+++ b/content/normal-modal-logic/tableaux/rules-for-K.tex
@@ -90,7 +90,7 @@ prefixes must match. So a branch is closed if it contains both
 for some prefix $\sigma$ and !!{formula}~$!A$.
 
 The rules for setting up assumptions is also as for ordinary
-!!{tableau}s, except that for asusmptions we always use the
+!!{tableau}s, except that for assumptions we always use the
 prefix~$1$. (It does not matter which prefix we use, as long as it's
 the same for all assumptions.) So, e.g., we say that
 \[
@@ -107,7 +107,7 @@ For the modal operator\iftag{prvBox}{\iftag{prvDiamond}{s~$\Box$
 the conclusion of the rule applied to !!a{formula} with
 prefix~$\sigma$ is $\sigma.n$. However, which $n$ is allowed depends
 on whether the sign is~$\True$ or~$\False$.
-  
+
 \iftag{prvBox}{The $\TRule{\Box}{\True}$ rule extends a branch
   containing $\sFmla{\True}{\Box !A}[\sigma]$ by
   $\sFmla{\True}{!A}[\sigma.n]$.\iftag{prvDiamond}{ Similarly,
@@ -168,7 +168,7 @@ The rules are given in \olref{tab:rules-K}.
   \ollabel{tab:rules-K}
 \end{table}
 
-The requirements that the restriction that the prefix for
+The requirement that the restriction that the prefix for
 \iftag{prvBox}{\TRule{\True}{\Box}}{\TRule{\False}{\Diamond}} must be
 used is necessary as otherwise we would count the following as a
 closed !!{tableau}:

--- a/content/normal-modal-logic/tableaux/soundness.tex
+++ b/content/normal-modal-logic/tableaux/soundness.tex
@@ -7,7 +7,7 @@
 \begin{document}
 
 \olfileid{nml}{tab}{sou}
-      
+
 \olsection{Soundness for \Log{K}}
 
 \begin{editorial}
@@ -116,7 +116,7 @@ have to show that the extended branch, i.e., $\Gamma$ together with
 the conclusions of the rule, is still satisfiable. If the rule results
 in split branch, we have to show that at least one of the two
 resulting branches is satisfiable.
-\tagfalse{prvDiamond}  
+\tagfalse{prvDiamond}
 First, we consider the possible inferences with only one premise.
 \begin{enumerate}
 \item The branch is expanded by applying $\TRule{\True}{\lnot}$ to
@@ -233,9 +233,9 @@ Now let's consider the possible inferences with two premises.
   satisfies $\sFmla{\False}{!C}[\sigma]$, i.e., the right branch is
   satisfiable.
 \item The branch is expanded by applying $\TRule{\True}{\lor}$ to
-  $\sFmla{\True}{!B \lor !C} \in \Gamma$: Exercise.
+    $\sFmla{\True}{!B \lor !C}[\sigma] \in \Gamma$: Exercise.
 \item The branch is expanded by applying $\TRule{\True}{\lif}$ to
-  $\sFmla{\True}{!B \lif !C} \in \Gamma$: Exercise.
+    $\sFmla{\True}{!B \lif !C}[\sigma] \in \Gamma$: Exercise.
 \end{enumerate}
 \end{proof}
 

--- a/content/normal-modal-logic/tableaux/soundness.tex
+++ b/content/normal-modal-logic/tableaux/soundness.tex
@@ -138,7 +138,7 @@ First, we consider the possible inferences with only one premise.
   both $\sFmla{\True}{!B}[\sigma]$ and $\sFmla{\True}{!C}[\sigma]$
   with respect to~$f$.
 \item The branch is expanded by applying $\TRule{\False}{\lor}$ to
-  $\sFmla{\True}{!B \lor !C} \in \Gamma$: Exercise.
+  $\sFmla{\False}{!B \lor !C} \in \Gamma$: Exercise.
 \item The branch is expanded by applying $\TRule{\False}{\lif}$ to
   $\sFmla{\False}{!B \lif !C}[\sigma] \in \Gamma$: This results in two
   new !!{signed formula}s on the branch: $\sFmla{\True}{!B}[\sigma]$ and


### PR DESCRIPTION
The most dramatic change is the removal of two problems from `filtrations/S5-decidable.tex` that also appeared in `filtrations/S5-fmt.tex`. This made the problems appear twice in my Boxes and Diamonds. I wasn't sure where they should go, so I arbitrarily removed the duplicates in `S5-decidable.tex`.

Aside from this, fixes some typos in the Filtrations and Tableux chapters.
