### PR TITLE
Typo fixes

### DIFF
--- a/content/first-order-logic/introduction/first-order-logic.tex
+++ b/content/first-order-logic/introduction/first-order-logic.tex
@@ -68,7 +68,7 @@ The purpose of !!{derivation} systems is to provide tools using which the
 logicians' questions above can be answered: e.g., a natural deduction
 !!{derivation} in which $\lforall[x][(!A(x) \lif !B(x))$ and
 $\lexists[x][!A(x)]$ are premises and $\lexists[x][!B(x)]]$ is the
-conclusion (last line) \emph{verifies} that $\lexists[x][!B(x)]]$
+conclusion (last line) \emph{verifies} that $\lexists[x][!B(x)]$
 logically follows from $\lforall[x][(!A(x) \lif !B(x))]$ and
 $\lexists[x][!A(x)]$.  
 

--- a/content/first-order-logic/introduction/semantic-notions.tex
+++ b/content/first-order-logic/introduction/semantic-notions.tex
@@ -11,7 +11,7 @@
 \olsection{Semantic Notions}
 
 We mentioned above that when we consider whether $\Sat{M}{!A}[s]$
-holds, we (for convenience) let $s$ assign values to all !!{variable},
+holds, we (for convenience) let $s$ assign values to all !!{variable}s,
 but only the values it assigns to !!{variable}s in~$!A$ are used.  In
 fact, it's only the values of \emph{free} variables in~$!A$ that
 matter. Of course, because we're careful, we are going to prove this

--- a/content/first-order-logic/syntax-and-semantics/unique-readability.tex
+++ b/content/first-order-logic/syntax-and-semantics/unique-readability.tex
@@ -179,7 +179,7 @@ $!C$ and $!B'$, $!C'$ so that $!A$ is both of the form
 \begin{proof}
 The formation rules require that if !!a{formula} is not atomic, it
 must start with an opening parenthesis~(, \iftag{prvNot}{$\lnot$,}{}
-or with a quantifier. On the other hand, every !!{formula} that start with
+or with a quantifier. On the other hand, every !!{formula} that starts with
 one of the following symbols must be atomic: !!a{predicate}, !!a{function}, !!a{constant}\iftag{prvFalse}{, $\lfalse$}{}\iftag{prvTrue}{, $\ltrue$}{}.
 
 So we really only have to show that if $!A$ is of the form $(!B \ast

--- a/content/methods/induction/inductive-definitions.tex
+++ b/content/methods/induction/inductive-definitions.tex
@@ -102,8 +102,8 @@ length~$n$ is $< n/2$.
 To prove this result by (strong) induction, we have to show that the
 following conditional claim is true:
 \begin{quote}
-  If for every $l < k$, any nice term of length~$l$ has $l/2$
-  $[$'s, then any nice term of length~$k$ has $k/2$ $[$'s.
+  If for every $l < k$, any nice term of length~$l$ has $< l/2$
+  $[$'s, then any nice term of length~$k$ has $< k/2$ $[$'s.
 \end{quote}
 To show this conditional, assume that its antecedent is true, i.e.,
 assume that for any $l<k$, nice terms of length~$l$ contain $< l/2$
@@ -121,7 +121,7 @@ is~$0$. Since $0 < 1/2$, the claim holds.
   of~$s_2$.  Then the length~$k$ of $t$ is $l_1+l_2+3$ (the lengths of
   $s_1$ and $s_2$ plus three symbols $[$, $\circ$, $]$). Since
   $l_1+l_2+3$ is always greater than $l_1$, $l_1 < k$. Similarly, $l_2
-  < n$. That means that the induction hypothesis applies to the terms
+  < k$. That means that the induction hypothesis applies to the terms
   $s_1$ and~$s_2$: the number~$m_1$ of $[$ in $s_1$ is $< l_1/2$, and
   the number~$m_2$ of $[$ in~$s_2$ is $< l_2/2$.
 
@@ -129,7 +129,7 @@ is~$0$. Since $0 < 1/2$, the claim holds.
   number of $[$ in~$s_2$, plus~$1$, i.e., it is $m_1 + m_2 + 1$. Since $m_1
   < l_1/2$ and $m_2 < l_2/2$ we have:
   \[
-  m_1 + m_2 + 1 < \frac{l_1}{2} + \frac{l_2}{2} + 1 = \frac{l_1+l_2+2}{2} < \frac{l_1+l-2+3}{2} = k/2.
+  m_1 + m_2 + 1 < \frac{l_1}{2} + \frac{l_2}{2} + 1 = \frac{l_1+l_2+2}{2} < \frac{l_1+l_2+3}{2} = k/2.
   \]
 \end{enumerate}
 In each case, we've shown that the number of $[$ in $t$ is $< k/2$ (on

--- a/content/methods/induction/relations.tex
+++ b/content/methods/induction/relations.tex
@@ -23,7 +23,7 @@ give an inductive definition of this relation as follows:
   \sqsubseteq t_2$, is defined by induction on~$t_2$ as follows:
   \begin{enumerate}
   \item If $t_2$ is a letter, then $t_1 \sqsubseteq t_2$ iff $t_1 = t_2$.
-  \item If $t_2$ is $[s_1 \circ s_2]$, then $t_1 \sqsubseteq t_2$ iff $t =
+  \item If $t_2$ is $[s_1 \circ s_2]$, then $t_1 \sqsubseteq t_2$ iff $t_1 =
     t_2$, $t_1 \sqsubseteq s_1$, or $t_1 \sqsubseteq s_2$.
   \end{enumerate}
 \end{defn}
@@ -141,7 +141,7 @@ defined earlier. The corresponding ``definition'' would be:
   g(t) = 
   \begin{cases}
     0 & \text{ if $t$ is a letter}\\
-   \max(g(s), g(s')) + 1 & \text{ if $t = [s_1 \circ s_2]$.}
+   \max(g(s), g(s')) + 1 & \text{ if $t = s_1 \circ s_2$.}
   \end{cases}
 \]
 Now consider the bracketless term $\mathrm{a} \circ \mathrm{b} \circ

--- a/content/methods/induction/structural-induction.tex
+++ b/content/methods/induction/structural-induction.tex
@@ -55,8 +55,8 @@ nice terms out of old ones.
 \item Suppose the number of $[$ in $s_1$ equals the number of $]$, and
   the same is true for $s_2$. The number of $[$ in $o(s_1, s_2)$, i.e., in
     $[s_1 \circ s_2]$, is the sum of the number of $[$ in $s_1$ and
-      $s_2$. The number of $]$ in $o(s_1, s_2)$ is the sum of the number
-    of $]$ in $s_1$ and $s_2$. Thus, the number of $[$ in $o(s_1, s_2)$
+      $s_2$ plus one. The number of $]$ in $o(s_1, s_2)$ is the sum of the number
+    of $]$ in $s_1$ and $s_2$ plus one. Thus, the number of $[$ in $o(s_1, s_2)$
     equals the number of $]$ in $o(s_1,s_2)$.
 \end{enumerate}
 \end{proof}

--- a/content/methods/induction/structural-induction.tex
+++ b/content/methods/induction/structural-induction.tex
@@ -25,7 +25,7 @@ one operation: the operations are
   o(s_1, s_2) = & [s_1 \circ s_2]
 \end{align*}
 You can even think of the natural numbers~$\Nat$ themselves as being
-given be an inductive definition: the initial object is~$0$, and the
+given by an inductive definition: the initial object is~$0$, and the
 operation is the successor function~$x + 1$.
 
 In order to prove something about all elements of an inductively
@@ -47,7 +47,7 @@ individually.
 
 \begin{proof}
 We use structural induction.  Nice terms are inductively defined, with
-letters as initial objects and the operations $o$ for constructing new
+letters as initial objects and the operation $o$ for constructing new
 nice terms out of old ones.
 \begin{enumerate}
 \item The claim is true for every letter, since the number of $[$ in a


### PR DESCRIPTION
The reason why I added the phrase "plus one" to the end of those two sentences is that the sum of brackets in [ s_1 o s_2 ] should include the outer most brackets as well as the brackets in s_1 and s_2.