### PR TITLE
Some mixed proposals

### DIFF
--- a/content/first-order-logic/axiomatic-deduction/axioms-rules-quantifiers.tex
+++ b/content/first-order-logic/axiomatic-deduction/axioms-rules-quantifiers.tex
@@ -17,7 +17,7 @@ all instances of the following:
 \ollabel{ax:q1} & \lforall[x][!B] \lif !B(t), \\
 \ollabel{ax:q2} & !B(t) \lif \lexists[x][!B].
 \end{align}
-for any ground term~$t$.
+for any closed term~$t$.
 \end{defn}
 
 \begin{defn}[Rules for quantifiers]

--- a/content/first-order-logic/axiomatic-deduction/identity.tex
+++ b/content/first-order-logic/axiomatic-deduction/identity.tex
@@ -20,7 +20,7 @@ the same, we just also allow the new axioms.
 \ollabel{ax:id2} & \eq[t_1][t_2] \lif (!B(t_1) \lif
   !B(t_2)),
 \end{align}
-for any ground terms $t$, $t_1$, $t_2$.
+for any closed terms $t$, $t_1$, $t_2$.
 \end{defn}
 
 \begin{prop}\ollabel{prop:sound}

--- a/content/first-order-logic/completeness/construction-of-model.tex
+++ b/content/first-order-logic/completeness/construction-of-model.tex
@@ -73,6 +73,30 @@ Suppose $\Gamma^*$ is a complete consistent set of !!{formula}s. Then we let
 }
 
 \iftag{FOL}{%
+We will now check that we indeed have $\Value{t}{M(\Gamma^*)} = t$.
+
+\begin{lem} 
+\ollabel{lem:val-in-termmodel} Let $\Struct M(\Gamma^*)$ be the term model
+ of \olref{defn:termmodel}, then $\Value{t}{M(\Gamma^*)} = t$.
+\end{lem}
+\begin{proof} 
+ The proof is by induction on $t$, where the base case, when $t$
+ is a constant symbol, follows directly from the definition of the term
+ model. For the induction step assume $t_1, \ldots, t_n$ are closed terms
+ such that $\Value{t_i}{M(\Gamma^*)} = t_i$ and that $f$ is an $n$-ary
+ !!{function}. Then 
+\begin{align*}
+\Value{f(t_1,\ldots,t_n)}{M(\Gamma^*)} &= \Assign{f}{M(\Gamma^*)}(\Value{t_1}
+ {M(\Gamma^*)}, 
+\ldots, \Value{t_n}{M(\Gamma^*)}) \\
+&= \Assign{f}{M(\Gamma^*)}(t_1, \dots, t_n) \\
+&= f(t_1,\dots, t_n),
+\end{align*} 
+  and so by induction this holds for every closed term $t$.
+\end{proof}
+}
+
+\iftag{FOL}{%
 \begin{explain}
   \iftag{prvEx}{!!^a{structure}~$\Struct{M}$ may make an existentially
     quantified !!{sentence}~$\lexists[x][!A(x)]$ true without there

--- a/content/first-order-logic/completeness/identity.tex
+++ b/content/first-order-logic/completeness/identity.tex
@@ -154,6 +154,22 @@ $\Struct{\equivclass{M}{\approx}}$ is well defined, i.e., if $t_1$,
 Follows from \olref{prop:approx-equiv} by induction on~$n$.
 \end{proof}
 
+As in the case of the term model, before proving the truth lemma we need the
+following lemma.
+
+\begin{lem} 
+\ollabel{lem:val-in-termmodel-factored} Let $\Struct M = \Struct M
+ (\Gamma^*)$, then $\Value{t}{\equivclass{M}{\approx}} = \equivrep{t}
+ {\approx}$.
+\end{lem}
+\begin{proof} 
+The proof is similar to that of \olref[mod]{lem:val-in-termmodel}.
+\end{proof}
+
+\begin{prob}
+Complete the proof of~\olref[fol][com][ide]{lem:val-in-termmodel-factored}.
+\end{prob}
+
 \begin{lem}
 \ollabel{lem:truth}
 $\Sat{\equivclass{M}{\approx}}{!A}$ iff $!A \in \Gamma^*$ for all

--- a/content/first-order-logic/natural-deduction/quantifier-rules.tex
+++ b/content/first-order-logic/natural-deduction/quantifier-rules.tex
@@ -24,7 +24,7 @@
 \DisplayProof
 \end{defish}
 
-In the rules for~$\lforall$, $t$ is a ground term (a term that does
+In the rules for~$\lforall$, $t$ is a closed term (a term that does
 not contain any variables), and $a$~is a !!{constant} which does not
 occur in the conclusion~$\lforall[x][!A(x)]$, or in any assumption
 which is !!{undischarged} in the !!{derivation} ending with the
@@ -47,7 +47,7 @@ premise~$!A(a)$. We call $a$ the \emph{eigenvariable} of the
 \DisplayProof
 \end{defish}
 
-Again, $t$ is a ground term, and $a$ is a constant which does not
+Again, $t$ is a closed term, and $a$ is a constant which does not
 occur in the premise $\lexists[x][!A(x)]$, in the conclusion~$!C$, or
 any assumption which is !!{undischarged} in the !!{derivation}s ending
 with the two premises (other than the assumptions $!A(a)$).  We call

--- a/content/first-order-logic/natural-deduction/quantifier-rules.tex
+++ b/content/first-order-logic/natural-deduction/quantifier-rules.tex
@@ -13,34 +13,34 @@
 \subsection{Rules for $\lforall$}
 
 \begin{defish}
-\AxiomC{$!A(a)$}
+\AxiomC{$!\Subst{!A}{a}{x}$}
 \RightLabel{\Intro{\lforall}}
-\UnaryInfC{$\lforall[x][\Atom{!A}{x}]$}
+\UnaryInfC{$\lforall[x][!A]$}
 \DisplayProof
 \hfill
-\AxiomC{$\lforall[x][\Atom{!A}{x}]$}
+\AxiomC{$\lforall[x][!A]$}
 \RightLabel{\Elim{\lforall}}
-\UnaryInfC{$!A(t)$}
+\UnaryInfC{$!\Subst{!A}{t}{x}$}
 \DisplayProof
 \end{defish}
 
 In the rules for~$\lforall$, $t$ is a closed term (a term that does
 not contain any variables), and $a$~is a !!{constant} which does not
-occur in the conclusion~$\lforall[x][!A(x)]$, or in any assumption
+occur in the conclusion~$\lforall[x][!A]$, or in any assumption
 which is !!{undischarged} in the !!{derivation} ending with the
-premise~$!A(a)$. We call $a$ the \emph{eigenvariable} of the
+premise~$!\Subst{!A}{a}{x}$. We call $a$ the \emph{eigenvariable} of the
 \Intro{\lforall} inference.
 
 \subsection{Rules for $\lexists$}
 
 \begin{defish}
-\AxiomC{$\Atom{!A}{t}$}
+\AxiomC{$\Subst{!A}{t}{x}$}
 \RightLabel{\Intro{\lexists}}
-\UnaryInfC{$\lexists[x][\Atom{!A}{x}]$}
+\UnaryInfC{$\lexists[x][!A]$}
 \DisplayProof
 \hfill
-\AxiomC{$\lexists[x][\Atom{!A}{x}]$}
-\AxiomC{[$\Atom{!A}{a}$]$^n$}
+\AxiomC{$\lexists[x][!A]$}
+\AxiomC{[$\Subst{!A}{a}{x}$]$^n$}
 \DeduceC{$!C$}
 \DischargeRule{\Elim{\lexists}}{n}
 \BinaryInfC{$!C$}
@@ -48,9 +48,9 @@ premise~$!A(a)$. We call $a$ the \emph{eigenvariable} of the
 \end{defish}
 
 Again, $t$ is a closed term, and $a$ is a constant which does not
-occur in the premise $\lexists[x][!A(x)]$, in the conclusion~$!C$, or
+occur in the premise $\lexists[x][!A]$, in the conclusion~$!C$, or
 any assumption which is !!{undischarged} in the !!{derivation}s ending
-with the two premises (other than the assumptions $!A(a)$).  We call
+with the two premises (other than the assumptions $!\Subst{!A}{a}{x}$).  We call
 $a$ the \emph{eigenvariable} of the \Elim{\lexists} inference.
 
 The condition that an eigenvariable neither occur in the premises nor in
@@ -72,7 +72,7 @@ the system is sound, i.e., only !!{derive}s !!{sentence}s from
 !!{undischarged} assumptions from which they follow. Without this
 condition, the following would be allowed:
 \begin{prooftree}
-  \AxiomC{$\lexists[x][!A(x)]$}
+  \AxiomC{$\lexists[x][!A]$}
   \AxiomC{$\Discharge{!A(a)}{1}$}
   \RightLabel{*\Intro{\lforall}}
   \UnaryInfC{$\lforall[x][!A(x)]$}
@@ -80,6 +80,17 @@ condition, the following would be allowed:
   \BinaryInfC{$\lforall[x][!A(x)]$}
 \end{prooftree}
 However, $\lexists[x][!A(x)] \Entails/ \lforall[x][!A(x)]$.
+
+In the above derivation we have used $!A(a)$ as a short hand for $\Subst{!A}
+{a}{x}$. This is possible since the notation $\lforall[x][!A(x)]$ in the
+conclusion of the rule indicates that the variable used in the substitution
+is $x$.
+\end{explain}
+
+\begin{explain}
+As the elimination rules for quantifiers only allow substituting closed
+terms for variables, it follows that any formula that can be derived from a
+set of sentences is itself a sentence.
 \end{explain}
 
 

--- a/content/first-order-logic/natural-deduction/quantifier-rules.tex
+++ b/content/first-order-logic/natural-deduction/quantifier-rules.tex
@@ -53,6 +53,25 @@ any assumption which is !!{undischarged} in the !!{derivation}s ending
 with the two premises (other than the assumptions $!A(a)$).  We call
 $a$ the \emph{eigenvariable} of the \Elim{\lexists} inference.
 
+Recall the convention that when $!A$ is !!a{formula} with the !!
+{variable}~$x$ free, we indicate this by writing~$!A(x)$. In the same
+context, $!A(t)$ then is short for~$\Subst{!A}{t}{x}$.  So we could also
+write the $\Intro\lexists$ rule as 
+\begin{prooftree}
+\AxiomC{$\Subst{!A}{t}{x}$}
+\RightLabel{\Intro{\lexists}}
+\UnaryInfC{$\lexists[x][!A]$}
+\end{prooftree}
+Note that $t$ may already occur  in~$!A$, say, $!A$ might be 
+$\Atom{\Obj P}{t,x}$.  Thus, inferring $\lexists[x][\Atom{\Obj P}{t,x}]$ from 
+$\Atom{\Obj P}{t,t}$ is a correct application of~$\Intro\lexists$---you may
+``replace'' one or more, and not necessarily all, occurrences of~$t$ in
+the premise by the bound !!{variable}~$x$.  However, the eigenvariable
+conditions in $\Intro\lforall$ and $\Elim\lexists$ require that the !!
+{constant}~$a$ does not occur in~$!A$. So, you cannot correctly infer
+$\lforall[x][\Atom{\Obj P}{a,x}]$ from $\Atom{\Obj P}
+{a,a}$ using~$\Intro\lforall$.
+
 The condition that an eigenvariable neither occur in the premises nor in
 any assumption that is !!{undischarged} in the !!{derivation}s leading 
 to the premises for the \Intro{\lforall} or \Elim{\lexists} inference is 
@@ -80,6 +99,10 @@ condition, the following would be allowed:
   \BinaryInfC{$\lforall[x][!A(x)]$}
 \end{prooftree}
 However, $\lexists[x][!A(x)] \Entails/ \lforall[x][!A(x)]$.
+
+As the elimination rules for quantifiers only allow substituting closed terms
+for variables, it follows that any formula that can be derived from a set of
+sentences is itself a sentence.
 \end{explain}
 
 

--- a/content/first-order-logic/natural-deduction/quantifier-rules.tex
+++ b/content/first-order-logic/natural-deduction/quantifier-rules.tex
@@ -13,34 +13,34 @@
 \subsection{Rules for $\lforall$}
 
 \begin{defish}
-\AxiomC{$!\Subst{!A}{a}{x}$}
+\AxiomC{$!A(a)$}
 \RightLabel{\Intro{\lforall}}
-\UnaryInfC{$\lforall[x][!A]$}
+\UnaryInfC{$\lforall[x][\Atom{!A}{x}]$}
 \DisplayProof
 \hfill
-\AxiomC{$\lforall[x][!A]$}
+\AxiomC{$\lforall[x][\Atom{!A}{x}]$}
 \RightLabel{\Elim{\lforall}}
-\UnaryInfC{$!\Subst{!A}{t}{x}$}
+\UnaryInfC{$!A(t)$}
 \DisplayProof
 \end{defish}
 
 In the rules for~$\lforall$, $t$ is a closed term (a term that does
 not contain any variables), and $a$~is a !!{constant} which does not
-occur in the conclusion~$\lforall[x][!A]$, or in any assumption
+occur in the conclusion~$\lforall[x][!A(x)]$, or in any assumption
 which is !!{undischarged} in the !!{derivation} ending with the
-premise~$!\Subst{!A}{a}{x}$. We call $a$ the \emph{eigenvariable} of the
+premise~$!A(a)$. We call $a$ the \emph{eigenvariable} of the
 \Intro{\lforall} inference.
 
 \subsection{Rules for $\lexists$}
 
 \begin{defish}
-\AxiomC{$\Subst{!A}{t}{x}$}
+\AxiomC{$\Atom{!A}{t}$}
 \RightLabel{\Intro{\lexists}}
-\UnaryInfC{$\lexists[x][!A]$}
+\UnaryInfC{$\lexists[x][\Atom{!A}{x}]$}
 \DisplayProof
 \hfill
-\AxiomC{$\lexists[x][!A]$}
-\AxiomC{[$\Subst{!A}{a}{x}$]$^n$}
+\AxiomC{$\lexists[x][\Atom{!A}{x}]$}
+\AxiomC{[$\Atom{!A}{a}$]$^n$}
 \DeduceC{$!C$}
 \DischargeRule{\Elim{\lexists}}{n}
 \BinaryInfC{$!C$}
@@ -48,9 +48,9 @@ premise~$!\Subst{!A}{a}{x}$. We call $a$ the \emph{eigenvariable} of the
 \end{defish}
 
 Again, $t$ is a closed term, and $a$ is a constant which does not
-occur in the premise $\lexists[x][!A]$, in the conclusion~$!C$, or
+occur in the premise $\lexists[x][!A(x)]$, in the conclusion~$!C$, or
 any assumption which is !!{undischarged} in the !!{derivation}s ending
-with the two premises (other than the assumptions $!\Subst{!A}{a}{x}$).  We call
+with the two premises (other than the assumptions $!A(a)$).  We call
 $a$ the \emph{eigenvariable} of the \Elim{\lexists} inference.
 
 The condition that an eigenvariable neither occur in the premises nor in
@@ -72,7 +72,7 @@ the system is sound, i.e., only !!{derive}s !!{sentence}s from
 !!{undischarged} assumptions from which they follow. Without this
 condition, the following would be allowed:
 \begin{prooftree}
-  \AxiomC{$\lexists[x][!A]$}
+  \AxiomC{$\lexists[x][!A(x)]$}
   \AxiomC{$\Discharge{!A(a)}{1}$}
   \RightLabel{*\Intro{\lforall}}
   \UnaryInfC{$\lforall[x][!A(x)]$}
@@ -80,17 +80,6 @@ condition, the following would be allowed:
   \BinaryInfC{$\lforall[x][!A(x)]$}
 \end{prooftree}
 However, $\lexists[x][!A(x)] \Entails/ \lforall[x][!A(x)]$.
-
-In the above derivation we have used $!A(a)$ as a short hand for $\Subst{!A}
-{a}{x}$. This is possible since the notation $\lforall[x][!A(x)]$ in the
-conclusion of the rule indicates that the variable used in the substitution
-is $x$.
-\end{explain}
-
-\begin{explain}
-As the elimination rules for quantifiers only allow substituting closed
-terms for variables, it follows that any formula that can be derived from a
-set of sentences is itself a sentence.
 \end{explain}
 
 

--- a/content/first-order-logic/natural-deduction/soundness-identity.tex
+++ b/content/first-order-logic/natural-deduction/soundness-identity.tex
@@ -17,7 +17,7 @@ Natural deduction with rules for $\eq$ is sound.
 \begin{proof}
 Any !!{formula} of the form $\eq[t][t]$ is valid, since
 for every !!{structure}~$\Struct M$, $\Sat{M}{\eq[t][t]}$. (Note that
-we assume the term $t$ to be ground, i.e., it contains no variables,
+we assume the term $t$ to be closed, i.e., it contains no variables,
 so variable assignments are irrelevant).
 
 Suppose the last inference in !!a{derivation} is \Elim{\eq}, i.e., the

--- a/content/intuitionistic-logic/semantics/introduction.tex
+++ b/content/intuitionistic-logic/semantics/introduction.tex
@@ -58,7 +58,7 @@ $!A$ but not know~$\lfalse$.
 
 On this interpretation the principle of excluded middle fails. For
 there are some $!A$ which we don't yet know, but which we might come
-to know. For such an $!A$, both $!A$ and $\lnot !A$ are unknown, so
+to know. For such a formula $!A$, both $!A$ and $\lnot !A$ are unknown, so
 $!A \lor \lnot !A$ is not known. But we do know, e.g., that $\lnot(!A
 \land \lnot !A)$. For no future state in which we know both $!A$ and
 $\lnot !A$ is possible, and we know this independently of whether or

--- a/content/intuitionistic-logic/soundness-completeness/lindenbaum.tex
+++ b/content/intuitionistic-logic/soundness-completeness/lindenbaum.tex
@@ -112,8 +112,8 @@ a prime set of formulas:
 
   We now show that if $\Gamma^* \Proves !B \lor !C$, then either $!B
   \in \Gamma^*$ or $!C \in \Gamma^*$. This proves \olref{defn:prime3},
-  since if $!B \in \Gamma^*$ then also $\Gamma^* \Proves !B$, and
-  similarly for~$!C$. So assume $\Gamma^* \Proves !B \lor !C$ but $!B
+  since if $!B \lor !C \in \Gamma^*$ then also $\Gamma^* \Proves !B 
+  \lor !C$. So assume $\Gamma^* \Proves !B \lor !C$ but $!B
   \notin \Gamma^*$ and $!C \notin \Gamma^*$. Since $\Gamma^* \Proves
   !B \lor !C$, $\Gamma_n \Proves !B \lor !C$ for some~$n$. $!B \lor
   !C$ appears on the enumeration of all disjunctions, say, as $!B_j

--- a/content/model-theory/basics/substructures.tex
+++ b/content/model-theory/basics/substructures.tex
@@ -26,7 +26,7 @@ written $\Struct M \substruct \Struct M'$, iff
 \item $\Domain{M} \subseteq \Domain{M'}$,
 \item For each constant $c \in \Lang L$, $\Assign{c}{M} =
     \Assign{c}{M'}$;
-\item For each $n$-place !!{predicate} $f \in \Lang L$
+\item For each $n$-place !!{function} $f \in \Lang L$
   $\Assign{f}{M}(a_1, \dots, a_n) = \Assign{f}{M'}(a_1, \dots, a_n)$
   for all $a_1$, \dots, $a_n \in \Domain{M}$.
 \item For each $n$-place !!{predicate} $R \in \Lang L$, $\langle

--- a/content/second-order-logic/metatheory/second-order-arithmetic.tex
+++ b/content/second-order-logic/metatheory/second-order-arithmetic.tex
@@ -118,13 +118,4 @@ $\Setabs{m}{n \le m} \subseteq Y$, so we can take $!A_\le(x, y) \ident
 Complete the proof of \olref[sol][met][spa]{prop:sol-pa-definable}.
 \end{prob}
 
-\begin{cor}
-$\Sat{M}{\Th{PA^2}}$ iff $\Sat{M}{\Th{PA^{2\dagger}}}$.
-\end{cor}
-
-\begin{proof}
-Immediate from \olref[sol][met][spa]{prop:sol-pa-definable}.
-\end{proof}
-
-
 \end{document}

--- a/content/turing-machines/machines-computations/unary-numbers.tex
+++ b/content/turing-machines/machines-computations/unary-numbers.tex
@@ -148,29 +148,31 @@ to~$q_6$ labelled~$\TMtrans{\TMblank}{\TMblank}{\TMstay}$.
     \begin{tikzpicture}[->,>=stealth',shorten >=1pt,auto,node distance=2.8cm,
                         semithick]
       \tikzstyle{every state}=[fill=none,draw=black,text=black]
-    
-      \node[initial,state] (0)              {$q_6$};
-      \node[state]         (1) [right of=0] {$q_7$};
-      \node[state]         (2) [right of=1] {$q_8$};
-      \node[state]         (3) [below of=2] {$q_9$};
-      \node[state]         (4) [left of=3]  {$q_{10}$};
-      \node[state]         (5) [left of=4]  {$q_{11}$};
-      \node[state]         (6) [below of=5] {$q_{12}$};
-      \node[state]         (7) [right of=6] {$q_{13}$};
+
+      \node[initial,state] (6)              {$q_6$};
+      \node[state]         (7) [right of=6] {$q_7$};
+      \node[state]         (8) [right of=7] {$q_8$};
+      \node[state]         (9) [below of=8] {$q_9$};
+      \node[state]         (10) [left of=9] {$q_10$};
+      \node[state]         (11) [left of=10]  {$q_{11}$};
+      \node[state]         (12) [below of=11]  {$q_{12}$};
+      \node[state]         (13) [right of=12] {$q_{13}$};
+      \node[state]         (14) [right of=13] {$q_{14}$};
       \path 
-      (0) edge [loop above] node {\TMtrans{\TMblank}{\TMblank}{\TMright}} (0)
-      (0) edge node {\TMtrans{\TMstroke}{\TMstroke}{\TMright}} (1)
-      (1) edge [loop above] node {\TMtrans{\TMstroke}{\TMstroke}{\TMright}} (1)
-          edge node {\TMtrans{\TMblank}{\TMendtape}{\TMleft}} (2)
-        (2) edge [loop above] node {\TMtrans{\TMstroke}{\TMstroke}{\TMleft}} (2)
-            edge node {\TMtrans{\TMblank}{\TMblank}{\TMright}} (3)
-        (3) edge node[above] {\TMtrans{\TMblank}{\TMblank}{\TMleft}} (4)
-        (4) edge [loop above] node {\TMtrans{\TMblank}{\TMblank}{\TMleft}} (4)
-        edge        node[above] {\TMtrans{\TMendtape}{\TMendtape}{\TMright}} (5)
-        (5) edge              node[left] {\TMtrans{\TMblank}{\TMstroke}{\TMright}} (6)
-        (6) edge [loop left] node {\TMtrans{\TMblank}{\TMblank}{\TMright}} (6)
-            edge              node[sloped] {\TMtrans{\TMstroke}{\TMblank}{\TMleft}} (4)
-        (6) edge node {\TMtrans{\TMendtape}{\TMblank}{\TMstay}} (7);
+      (6)  edge node {\TMtrans{\TMblank}{\TMblank}{\TMright}} (7)
+      (7)  edge [loop above] node {\TMtrans{\TMblank}{\TMblank}{\TMright}} (7)
+           edge node {\TMtrans{\TMstroke}{\TMstroke}{\TMright}} (8)
+      (8)  edge [loop above] node {\TMtrans{\TMstroke}{\TMstroke}{\TMright}} (8)
+           edge node {\TMtrans{\TMblank}{\TMendtape}{\TMleft}} (9)
+      (9)  edge [loop right] node {\TMtrans{\TMstroke}{\TMstroke}{\TMleft}} (9)
+           edge node {\TMtrans{\TMblank}{\TMblank}{\TMright}} (10)
+      (10) edge node[above] {\TMtrans{\TMstroke}{\TMblank}{\TMleft}} (11)
+      (11) edge [loop above] node {\TMtrans{\TMblank}{\TMblank}{\TMleft}} (11)
+           edge node[left] {$\genfrac{}{}{0pt}{0}{\TMtrans{\TMendtape}{\TMendtape}{\TMright}}{\TMtrans{\TMstroke}{\TMstroke}{\TMright}}$} (12)
+      (12) edge node[] {\TMtrans{\TMblank}{\TMstroke}{\TMright}} (13)
+      (13) edge [loop below] node {\TMtrans{\TMblank}{\TMblank}{\TMright}} (13)
+           edge node[sloped] {\TMtrans{\TMstroke}{\TMblank}{\TMleft}} (11)
+      (13) edge node {\TMtrans{\TMendtape}{\TMblank}{\TMstay}} (14);
         \end{tikzpicture}
     \]
     \caption{Moving a block of $\TMstroke$'s to the left}

--- a/content/turing-machines/undecidability/universal-tm.tex
+++ b/content/turing-machines/undecidability/universal-tm.tex
@@ -73,7 +73,7 @@ A remarkable result is the following:
   works, and then invoke the Church-Turing thesis.  When it starts,
   $U$'s tape contains a block of $e$ $\TMstroke$'s followed by a block
   of $n$~$\TMstroke$'s. It first ``decodes'' the index~$e$ to the
-  right of the input~$n$. This is produces a list of numbers (i.e.,
+  right of the input~$n$. This produces a list of numbers (i.e.,
   blocks of $\TMstroke$'s separated by~$\TMblank$'s) that describes
   the instructions of machine~$M_e$. $U$ then writes the number of the
   start state of~$M_e$ and the number~$1$ on the tape to the right of


### PR DESCRIPTION
A few typos and proposed changes. Main changes:
- Using A[t/x] instead of A(t) in the ND-rules for FOL. Then a short comment on that A(t) will do in many contexts.
- Val(t)=t for the term model is used but not proved. Even though the proof isn't very interesting I think it makes sense to state this as a lemma.
- In the section on SOA the last corollary isn't correct. To correct it we need to complicate things a bit. I think it's enough to mention that addition and multiplication are definable. That already indicates that we don't "need" the axioms for addition and multiplication. 