### PR TITLE
Few little typo fixes

### DIFF
--- a/content/methods/induction/induction-on-N.tex
+++ b/content/methods/induction/induction-on-N.tex
@@ -78,7 +78,7 @@ the inductive hypothesis.
 The inductive hypothesis says we can get any number between $k$
 and~$6k$ using $k$~dice.  If we throw a~$1$ with our $(k+1)$-st die,
 this adds $1$ to the total. So we can throw any value between $k+1$
-and $6k+1$ by throwing $5$~dice and then rolling a~$1$ with the
+and $6k+1$ by throwing $k$~dice and then rolling a~$1$ with the
 $(k+1)$-st die.  What's left?  The values $6k+2$ through $6k+6$.  We
 can get these by rolling $k$ $6$s and then a number between $2$ and
 $6$ with our $(k+1)$-st die. Together, this means that with $k+1$ dice

--- a/content/methods/proofs/using-definitions.tex
+++ b/content/methods/proofs/using-definitions.tex
@@ -103,7 +103,7 @@ themselves. Of course, it won't always be this simple.
 \begin{prob}
 Suppose you are asked to prove that $A \cap B \neq \emptyset$. Unpack
 all the definitions occuring here, i.e., restate this in a way that
-does not mention ``$\cap$'', ``='', or ``$\emptyset$.
+does not mention ``$\cap$'', ``='', or ``$\emptyset$''.
 \end{prob}
 
 \end{document}

--- a/content/model-theory/basics/reducts-and-expansions.tex
+++ b/content/model-theory/basics/reducts-and-expansions.tex
@@ -11,7 +11,7 @@
 
 Often it is useful or necessary to compare languages which have
 symbols in common, as well as !!{structure}s for these languages.  The
-most comon case is when all the symbols in !!a{language}~$\Lang{L}$
+most common case is when all the symbols in !!a{language}~$\Lang{L}$
 are also part of !!a{language}~$\Lang{L'}$, i.e., $\Lang{L} \subseteq
 \Lang{L'}$. An $\Lang{L}$-!!{structure}~$\Struct{M}$ can then always
 be expanded to an $\Lang{L'}$-!!{structure} by adding interpretations


### PR DESCRIPTION
Fixed a few typos.

_comon_ → _common_

Added closing bracket:
_“∩”, “=”, or “∅_ → _“∩”, “=”, or “∅”_ 

Changed 5 to k as we are throwing k dice, not 5 (makes more sense when reading the entire paragraph):
_So we can throw any value between k + 1 and 6k + 1 by throwing 5 dice and then rolling a 1 with the (k + 1)-st die_ → _So we can throw any value between k + 1 and 6k + 1 by throwing k dice and then rolling a 1 with the (k + 1)-st die_
