### PR TITLE
Correction in proof that OpenAssum relation is primitive recursive

### DIFF
--- a/content/computability/recursive-functions/introduction.tex
+++ b/content/computability/recursive-functions/introduction.tex
@@ -24,7 +24,7 @@ natural numbers) share an interesting feature: they can be defined
 \emph{recursively}.  It is thus quite natural to attempt a general
 definition of \emph{computable function} on the basis of recursive
 definitions.  Among the many possible ways to define number-theoretic
-functions recursively, one particulalry simple pattern of definition
+functions recursively, one particularly simple pattern of definition
 here becomes central: so-called \emph{primitive recursion}.
 
 In addition to computable functions, we might be interested in

--- a/content/computability/recursive-functions/non-pr-functions.tex
+++ b/content/computability/recursive-functions/non-pr-functions.tex
@@ -38,7 +38,7 @@ g_{n + 1}(x) & = & g_n^x(x)
 You can confirm that each function $g_n$ is primitive recursive. Each
 successive function grows much faster than the one before; $g_1(x)$ is
 equal to $2x$, $g_2(x)$ is equal to $2^x \cdot x$, and $g_3(x)$ grows
-roughly like an exponential stack of $x$ $2$'s. The Ackermann-P\'eter
+roughly like an exponential stack of $x$ $2$'s. The Ackermann--P\'eter
 function is essentially the function $G(x) = g_x(x)$, and one can show
 that this grows faster than any primitive recursive function.
 

--- a/content/computability/recursive-functions/trees.tex
+++ b/content/computability/recursive-functions/trees.tex
@@ -59,7 +59,7 @@ single nodes (labelled $l_2$, $l_3$) would be coded by $\tuple{2,
     \begin{align*}
       \fn{hSubtreeSeq}(t, 0) & = \tuple{t} \\
       \fn{hSubtreeSeq}(t, n+1) & = \fn{hSubtreeSeq}(t, n) \concat
-      h(\fn{hSubtree}(t, n)).
+      h(\fn{hSubtreeSeq}(t, n)).
     \end{align*}
     The maximum level of subtrees in a tree coded by~$t$, i.e., the
     maximum distance between the root and a leaf node, is bounded by

--- a/content/first-order-logic/natural-deduction/quantifier-rules.tex
+++ b/content/first-order-logic/natural-deduction/quantifier-rules.tex
@@ -53,8 +53,7 @@ Again, $t$ is a closed term, and $a$ is a constant which does not
 occur in the premise $\lexists[x][!A(x)]$, in the conclusion~$!C$, or
 any assumption which is !!{undischarged} in the !!{derivation}s ending
 with the two premises (other than the assumptions $!A(a)$). We call
-$a$ the \emph{eigenvariable} of the \Elim{\lexists}
-inference.
+$a$ the \emph{eigenvariable} of the \Elim{\lexists} inference.
 
 The condition that an eigenvariable neither occur in the premises nor
 in any assumption that is !!{undischarged} in the !!{derivation}s

--- a/content/first-order-logic/syntax-and-semantics/satisfaction.tex
+++ b/content/first-order-logic/syntax-and-semantics/satisfaction.tex
@@ -88,7 +88,7 @@ as an $x$-variant of itself.
   If $s$ is !!a{variable} assignment for !!a{structure}~$\Struct M$
   and $m \in \Domain{M}$, then the assignment~$\Subst{s}{m}{x}$ is the
   variable assignment defined by
-  \[\Subst{s}{m}{y} = \begin{cases}
+  \[\Subst{s}{m}{x}(y) = \begin{cases}
     m & \text{if } y \ident x\\
     s(y) & \text{otherwise}.
   \end{cases}\]

--- a/content/history/biographies/julia-robinson.tex
+++ b/content/history/biographies/julia-robinson.tex
@@ -64,7 +64,7 @@ Hilbert's tenth problem is undecidable
 problem throughout the 1960s.  In 1970, the young Russian
 mathematician Yuri Matijasevich finally proved the J.R. hypothesis.
 The combined result is now called the
-Matijasevich--Robinson--Davis--Putnam theorem, or MDRP theorem for short.
+Matijasevich--Robinson--Davis--Putnam theorem, or MRDP theorem for short.
 Matijasevich and Robinson became friends and collaborated on several
 papers. In a letter to Matijasevich, Robinson once wrote that
 ``actually I am very pleased that working together (thousands of miles

--- a/content/history/biographies/rozsa-peter.tex
+++ b/content/history/biographies/rozsa-peter.tex
@@ -45,7 +45,7 @@ In \cite{Peter1935b}, she showed that a certain recursively defined
 function is not primitive recursive. This simplified an earlier result
 due to Wilhelm Ackermann. P\'eter's simplified function is what's now
 often called the Ackermann function---and sometimes, more properly,
-the Ackermann-P\'eter function. She wrote the first book on recursive
+the Ackermann--P\'eter function. She wrote the first book on recursive
 function theory \citep{Peter1951}.
 
 Despite the importance and influence of her work, P\'eter did not

--- a/content/incompleteness/arithmetization-syntax/coding-formulas.tex
+++ b/content/incompleteness/arithmetization-syntax/coding-formulas.tex
@@ -51,13 +51,7 @@ of~$s$.
 \begin{prob}
 Give a detailed proof of \olref[inc][art][frm]{prop:frm-primrec} along
 the lines of the first proof of
-\olref[inc][art][trm]{prop:term-primrec}
-\end{prob}
-
-\begin{prob}
-Give a detailed proof of \olref[inc][art][frm]{prop:frm-primrec} along
-the lines of the alternate proof of
-\olref[inc][art][trm]{prop:term-primrec}
+\olref[inc][art][trm]{prop:term-primrec}.
 \end{prob}
 
 \begin{prop}

--- a/content/incompleteness/arithmetization-syntax/proofs-in-nd.tex
+++ b/content/incompleteness/arithmetization-syntax/proofs-in-nd.tex
@@ -276,9 +276,9 @@ recursive relation of the G\"odel numbers of $\delta$ and~$!A$.
   !!{discharged} and !!{undischarged} occurrences of~$!A$.
 
   Consider a sequence $\delta_0$, \dots, $\delta_k$ where $\delta_0 =
-  d$, $\delta_k$ is the assumption $\Discharge{!A}{n}$ (for some~$n$),
-  and $\delta_{i}$ is an immediate sub-!!{derivation}
-  of~$\delta_{i+1}$. If such a sequence exists in which no $\delta_i$
+  \delta$, $\delta_k$ is the assumption $\Discharge{!A}{n}$
+  (for some~$n$), and $\delta_{i+1}$ is an immediate sub-!!{derivation}
+  of~$\delta_i$. If such a sequence exists in which no $\delta_i$
   ends in an inference with discharge label~$n$, then $!A$ is
   !!a{undischarged} assumption of~$\delta$.
 
@@ -295,7 +295,7 @@ recursive relation of the G\"odel numbers of $\delta$ and~$!A$.
     \bexists{s<\fn{SubtreeSeq}(d)}{(\fn{Subseq}(s, \fn{SubtreeSeq}(d))
       \land (s)_0 = d \land {}} \\
     \bexists{n<d}{((s)_{\len{s} \tsub 1} = \tuple{0, z, n} \land {}}\\
-      \bforall{i<(\len{s} \tsub 1)}{(\fn{Subderiv}((s)_i, (s)_{i+1})] \land {}}\\
+      \bforall{i<(\len{s} \tsub 1)}{(\fn{Subderiv}((s)_{i+1}, (s)_i)] \land {}}\\
       \fn{DischargeLabel}((s)_{i+1}) \neq n))).
   \end{multline*}
 \end{proof}

--- a/content/incompleteness/introduction/definitions.tex
+++ b/content/incompleteness/introduction/definitions.tex
@@ -59,7 +59,7 @@ N$ defined as follows:
 Note the difference between $\times$ and $\cdot$: $\times$ is a symbol
 in the language of arithmetic. Of course, we've chosen it to remind us
 of multiplication, but $\times$ is not the multiplication operation
-but a two-place function symbol (officially, $\Obj f^2_1$. By
+but a two-place function symbol (officially, $\Obj f^2_1$). By
 contrast, $\cdot$ \emph{is} the ordinary multiplication function. When
 you see something like $n \cdot m$, we mean the product of the numbers
 $n$ and $m$; when you see something like $x \times y$ we are talking
@@ -137,19 +137,19 @@ schema.
 \begin{explain}
 Every instance of the induction schema is true in~$\Struct{N}$. This
 is easiest to see if the !!{formula}~$!A$ only has one free
-!!{variable}~$x$.  Then $!A(x)$ defines a subset~$X_A$ of~$\Nat$
-in~$\Struct{N}$.  $X_A$ is the set of all~$n \in \Nat$ such that
+!!{variable}~$x$.  Then $!A(x)$ defines a subset~$X_{!A}$ of~$\Nat$
+in~$\Struct{N}$.  $X_{!A}$ is the set of all~$n \in \Nat$ such that
 $\Sat{N}{!A(x)}[s]$ when $s(x) = n$.  The corresponding instance of
 the induction schema is
 \[
 ((!A(\Obj 0) \land \lforall[x][(!A(x) \lif !A(x'))]) \lif 
   \lforall[x][!A(x)]).
 \]
-If its antecedent is true in~$\Struct{N}$, then $0 \in X_A$ and,
-whenever $n \in X_A$, so is $n+1$.  Since $0 \in X_A$, we get $1 \in
-X_A$. With $1 \in X_A$ we get $2 \in X_A$. And so on. So for every $n
-\in \Nat$, $n \in X_A$. But this means that $\lforall[x][!A(x)]$ is
-satisfied in~$\Struct{N}$.
+If its antecedent is true in~$\Struct{N}$, then $0 \in X_{!A}$ and,
+whenever $n \in X_{!A}$, so is $n+1$.  Since $0 \in X_{!A}$, we get
+$1 \in X_{!A}$. With $1 \in X_{!A}$ we get $2 \in X_{!A}$. And so on.
+So for every $n \in \Nat$, $n \in X_{!A}$. But this means that
+$\lforall[x][!A(x)]$ is satisfied in~$\Struct{N}$.
 \end{explain}
 
 Both $\Th{Q}$ and $\Th{PA}$ are axiomatized theories.  The big

--- a/content/incompleteness/introduction/overview.tex
+++ b/content/incompleteness/introduction/overview.tex
@@ -43,12 +43,12 @@ We can in fact relatively quickly prove that there must be independent
 sentences. But the power of G\"odel's proof of the theorem lies in the
 fact that it exhibits a \emph{specific example} of such an independent
 !!{sentence}. The intriguing construction produces
-!!a{sentence}~$G_\Gamma$, called a \emph{G\"odel sentence}
-for~$\Gamma$, which is unprovable because in $\Gamma$, $G_\Gamma$ is
-equivalent to the claim that $G_\Gamma$ is unprovable in~$\Gamma$.  It
+!!a{sentence}~$!G_\Gamma$, called a \emph{G\"odel sentence}
+for~$\Gamma$, which is unprovable because in $\Gamma$, $!G_\Gamma$ is
+equivalent to the claim that $!G_\Gamma$ is unprovable in~$\Gamma$.  It
 does so \emph{constructively}, i.e., given an axiomatization
 of~$\Gamma$ and a description of the !!{derivation} system, the proof gives a
-method for actually writing down~$G_\Gamma$.
+method for actually writing down~$!G_\Gamma$.
 
 The construction in G\"odel's proof requires that we find a way to
 express in $\Lang L_A$ the properties of and operations on terms and

--- a/content/incompleteness/introduction/undecidability.tex
+++ b/content/incompleteness/introduction/undecidability.tex
@@ -128,7 +128,7 @@ It should be noted that not every \emph{interesting} theory is
 incomplete or undecidable. There are many theories that are
 sufficiently strong to describe interesting mathematical facts that do
 not satisify the conditions of G\"odel's result. For instance,
-$\Th{Pres} = \Setabs{!A \in \Lang{L_{A^+}}}{\Sat{\Nat}{!A}}$, the set of
+$\Th{Pres} = \Setabs{!A \in \Lang{L_{A^+}}}{\Sat{N}{!A}}$, the set of
 !!{sentence}s of the language of arithmetic without~$\times$ true in
 the standard model, is both complete and decidable. This theory is
 called Presburger arithmetic, and proves all the truths about natural

--- a/content/propositional-logic/propositional-logic.tex
+++ b/content/propositional-logic/propositional-logic.tex
@@ -8,7 +8,7 @@
 
 \begin{editorial}
   This part contains material on classical propositional logic. The
-  first chapter is relatively rudimenatry and just lists definitions
+  first chapter is relatively rudimentary and just lists definitions
   and results, many proofs are not carried out but are left as
   exercises. The material on proof systems and the completeness
   theorem is included from the part on first-order logic, with the

--- a/content/propositional-logic/syntax-and-semantics/formulas.tex
+++ b/content/propositional-logic/syntax-and-semantics/formulas.tex
@@ -44,7 +44,7 @@ above, we also use the following \emph{defined} symbols:
   \iftag{defIf}{\ycomma $\lif$ (!!{conditional})}{}%
   \iftag{defIff}{\ycomma $\liff$ (!!{biconditional})}{}%
   \iftag{defFalse}{\ycomma $\lfalse$ (!!{falsity})}{}%
-  \iftag{defTrue}{\ycomma $\ltrue$ (!!{truth})}.}{}
+  \iftag{defTrue}{\ycomma $\ltrue$ (!!{truth})}}{}.
 
 \begin{tagblock}{defNot,defOr,defAnd,defIf,defIff,defTrue,defFalse,defEx,defAll}
 \begin{explain}
@@ -87,7 +87,7 @@ is defined inductively as follows:
 \item Every !!{propositional variable}~$\Obj p_i$ is an atomic
   !!{formula}.
 
-\tagitem{prvNot}{If $!A$ is !!a{formula}, then $\lnot !A$ is
+\tagitem{prvNot}{If $!A$ is !!a{formula}, then $\lnot !A$ is a
   !!{formula}.}{}
 
 \tagitem{prvAnd}{If $!A$ and $!B$ are !!{formula}s, then $(!A \land

--- a/content/propositional-logic/syntax-and-semantics/introduction.tex
+++ b/content/propositional-logic/syntax-and-semantics/introduction.tex
@@ -50,7 +50,7 @@ rules.  The inductive definition resulting in expressions that are
 expressions using the same method---inductive definition.
 
 Giving the meaning of expressions is the domain of semantics.  The
-central concept in semantics for propositonal logic is that of
+central concept in semantics for propositional logic is that of
 satisfaction in !!a{valuation}. !!^a{valuation}~$\pAssign{v}$ assigns
 truth values $\True$, $\False$ to the !!{propositional variable}s. Any
 !!{valuation} determines a truth value $\pValue{v}(!A)$ for any

--- a/courses/enderton/open-logic-enderton-envs.sty
+++ b/courses/enderton/open-logic-enderton-envs.sty
@@ -1,4 +1,4 @@
-% % Enviornments file for examples/open-logic-enderton
+% % Environments file for examples/open-logic-enderton
 % % OpenLogic Project
 %
 % Description

--- a/open-logic-config.sty
+++ b/open-logic-config.sty
@@ -1048,7 +1048,7 @@
 \DeclareDocumentCommand \Obj { m }{\mathsfit{#1}}
 
 %  - `\Atom{P}{t_1, t_2)` - Atomic formula or term; default produces
-%  predicate symbol followed by argumnets surrounded by
+%  predicate symbol followed by arguments surrounded by
 %  parentheses. Some prefer no parentheses around the arguments.
 
 \DeclareDocumentCommand \Atom { m m }{ \mathord{#1}(#2) }

--- a/sty/open-logic-book-envs.sty
+++ b/sty/open-logic-book-envs.sty
@@ -161,8 +161,8 @@
 % OLP texts make use of a number of environments to encapsulate types
 % of discursive text.  By default, these environments simply print
 % their content without any special treatment. If you want to typeset
-% any of them differntly, you can change the definition of the
-% environment here. E.g., you might want digressions in asmaller font
+% any of them differently, you can change the definition of the
+% environment here. E.g., you might want digressions in a smaller font
 % and indented.  Refer to the \LaTeX\ documentation for how to
 % accomplish this.
 


### PR DESCRIPTION
Sub-derivations should get smaller as i increases, not larger. This commit corrects that in both the prose explanation and in the formal definition of the OpenAssum relation.