### PR TITLE
Fix typo (def of satisfaction in prop. logic)

### DIFF
--- a/content/propositional-logic/syntax-and-semantics/valuations-sat.tex
+++ b/content/propositional-logic/syntax-and-semantics/valuations-sat.tex
@@ -167,7 +167,7 @@ define the notion of \emph{satisfaction of !!a{formula}~$!A$ by
 
 \tagitem{prvOr}{%
   \indcase{!A}{(!B \lor !C)}{$\pSat{v}{\indfrm}$ iff
-    $\pSat{v}{!A}$ or $\pSat{v}{!B}$ (or both).}}{}
+    $\pSat{v}{!B}$ or $\pSat{v}{!C}$ (or both).}}{}
 
 \tagitem{prvIf}{%
   \indcase{!A}{(!B \lif !C)}{$\pSat{v}{\indfrm}$ iff $\pSat/{v}{!B}$


### PR DESCRIPTION
As it is explained in the commit message, in the disjunctive case: φ ≡ (ψ ∨ χ), it should be 
```
σ ⊨ φ iff σ ⊨ ψ or σ ⊨ χ, 
```
and not 
```
σ ⊨ φ iff σ ⊨ φ or σ ⊨ ψ
              ^^
```