### PR TITLE
Fix typos in FOL syntax chapter

### DIFF
--- a/content/first-order-logic/syntax-and-semantics/first-order-languages.tex
+++ b/content/first-order-logic/syntax-and-semantics/first-order-languages.tex
@@ -119,17 +119,17 @@ the longer our proofs.
 
 \begin{intro}
 You may be familiar with different terminology and symbols than the
-ones we use above. Logic texts (and teachers) commonly use either
-$\sim$, $\neg$, and~!\ for ``negation'', $\wedge$, $\cdot$, and $\&$
+ones we use above. Logic texts (and teachers) commonly use 
+$\sim$, $\neg$, or~!\ for ``negation'', $\wedge$, $\cdot$, or $\&$
 for ``conjunction''.  Commonly used symbols for the ``conditional'' or
 ``implication'' are $\rightarrow$, $\Rightarrow$, and $\supset$.
 \iftag{prvIff,defIff}{Symbols for ``biconditional,'' ``bi-implication,''
   or ``(material) equivalence'' are $\leftrightarrow$,
   $\Leftrightarrow$, and $\equiv$.}{}
 \iftag{prvFalse,defFalse}{The $\lfalse$ symbol is variously called
-  ``falsity,'' ``falsum,'', ``absurdity,'', or ``bottom.''}{}
+  ``falsity,'' ``falsum,'', ``absurdity,'' or ``bottom.''}{}
 \iftag{prvTrue,defTrue}{The $\ltrue$ symbol is variously called
-  ``truth,'' ``verum,'', or ``top.''}{}
+  ``truth,'' ``verum,'' or ``top.''}{}
 
 It is conventional to use lower case letters (e.g., $a$, $b$, $c$) from
 the beginning of the Latin alphabet for !!{constant}s (sometimes called

--- a/content/first-order-logic/syntax-and-semantics/free-vars-sentences.tex
+++ b/content/first-order-logic/syntax-and-semantics/free-vars-sentences.tex
@@ -70,8 +70,8 @@ Consider the following formula:
 \lexists[\Obj v_0][\underbrace{\Atom{\Obj A^2_0}{\Obj v_0,\Obj v_1}}_{!B}] 
 \]
 $!B$ represents the scope of $\lexists[\Obj v_0]$. 
-The quantifier binds the occurence of $\Obj v_0$ in $!B$, but
-does not bind the occurence of $\Obj v_1$. So $\Obj v_1$ is
+The quantifier binds the occurrence of $\Obj v_0$ in $!B$, but
+does not bind the occurrence of $\Obj v_1$. So $\Obj v_1$ is
 a free variable in this case.
 
 
@@ -85,7 +85,7 @@ We can now see how this might work in a more complicated
 $!B$ is the scope of the first $\lforall[\Obj v_0]$, $!C$ is the scope
 of $\lexists[\Obj v_1]$, and $!D$ is the scope of the second
 $\lforall[\Obj v_0]$.  The first $\lforall[\Obj v_0]$ binds the
-occurrences of $\Obj v_0$ in~$!B$, $\lexists[\Obj v_1]$ the occurrence
+occurrences of $\Obj v_0$ in~$!B$, $\lexists[\Obj v_1]$ binds the occurrence
 of $\Obj v_1$ in $!C$, and the second $\lforall[\Obj v_0]$ binds the
 occurrence of $\Obj v_0$ in~$!D$.  The first occurrence of $\Obj v_1$
 and the fourth occurrence of $\Obj v_0$ are free in~$!A$. The last

--- a/content/first-order-logic/syntax-and-semantics/main-operator.tex
+++ b/content/first-order-logic/syntax-and-semantics/main-operator.tex
@@ -85,6 +85,7 @@ $\lnot$ & negation & $\lnot !A$ \\
 $\land$ & conjunction & $(!A \land !B$) \\
 $\lor$ & disjunction & $(!A \lor !B$) \\
 $\lif$ & !!{conditional} & $(!A \lif !B$) \\
+$\liff$ & !!{biconditional} & $(!A \liff !B$) \\
 \iftag{prvIff,defIff}{}{$\liff$ & !!{biconditional} & $!A \liff !B$ \\}
 $\lforall[][]$ & universal (!!{formula})& $\lforall[x][!A]$ \\
 $\lexists[][]$ & existential (!!{formula})& $\lexists[x][!A]$

--- a/content/first-order-logic/syntax-and-semantics/substitution.tex
+++ b/content/first-order-logic/syntax-and-semantics/substitution.tex
@@ -105,7 +105,7 @@ quantifier $\lexists[y]$ upon substitution, and that is undesirable.
 For instance, we would like it to be the case that whenever
 $\lforall[x][!B]$ holds, so does $\Subst{!B}{t}{x}$. But consider
 $\lforall[x][\lexists[y][x < y]]$ (here $!B$ is $\lexists[y][x <
-  y]$). It is sentence that is true about, e.g., the natural numbers:
+  y]$). It is a sentence that is true about, e.g., the natural numbers:
 for every number~$x$ there is a number~$y$ greater than it. If we
 allowed $y$ as a possible substitution for~$x$, we would end up with
 $\Subst{!B}{y}{x} \ident \lexists[y][y < y]$, which is false. We

--- a/content/first-order-logic/syntax-and-semantics/unique-readability.tex
+++ b/content/first-order-logic/syntax-and-semantics/unique-readability.tex
@@ -127,7 +127,7 @@ Prove \olref[fol][syn][unq]{lem:no-prefix}.
 
 \begin{prop}
 \ollabel{prop:unique-atomic}
-If $!A$ is an atomic !!{formula}, then it satisfes one, and only one
+If $!A$ is an atomic !!{formula}, then it satisfies one, and only one
 of the following conditions.
 \begin{enumerate}
 \tagitem{prvFalse}{$!A \ident \lfalse$.}{}
@@ -179,7 +179,7 @@ $!C$ and $!B'$, $!C'$ so that $!A$ is both of the form
 \begin{proof}
 The formation rules require that if !!a{formula} is not atomic, it
 must start with an opening parenthesis~(, \iftag{prvNot}{$\lnot$,}{}
-or with a quantifier. On the other hand, every !!{formula} that starts with
+or a quantifier. On the other hand, every !!{formula} that starts with
 one of the following symbols must be atomic: !!a{predicate}, !!a{function}, !!a{constant}\iftag{prvFalse}{, $\lfalse$}{}\iftag{prvTrue}{, $\ltrue$}{}.
 
 So we really only have to show that if $!A$ is of the form $(!B \ast

--- a/courses/mybook/mybook.tex
+++ b/courses/mybook/mybook.tex
@@ -1,0 +1,197 @@
+% Open Logic Project
+%
+% driver file open-logic-sample.tex to produce text on letter-size paper
+% with standard layout and margins
+
+% We use the memoir class for maximal flexibility of layout, but any
+% class will do
+
+\documentclass[letterpaper]{memoir}
+
+% \olpath has to point to the location of the OLP main
+% directory/folder.  We're compiling from subdirectory courses/sample,
+% so the main directory is two levels up.
+\newcommand{\olpath}{../../}
+
+% load all the Open Logic definitions. This will also load the
+% local definitions in open-logic-sample-config.sty
+\input{\olpath/sty/open-logic.sty}
+
+% we want all the problems deferred to the end
+\input{\olpath/sty/open-logic-defer.sty}
+
+% let's set the whole thing in Palatino, with Helvetica for
+% sans-serif, and spread the lines a bit to make the text more
+% readable
+
+\usepackage{mathpazo}
+\usepackage[scaled=0.95]{helvet}
+\linespread{1.05}
+
+\begin{document}
+
+% First we make a titlepage
+
+\begin{titlingpage}
+\begin{raggedleft}
+\fontsize{52pt}{2em}\selectfont\bfseries\sffamily
+Sample\\[.5ex] 
+Logic\\[.5ex] 
+Text
+\vskip 4ex
+\normalfont\Huge\textbf{\href{http://openlogicproject.org/}{Open Logic Project}}
+
+\end{raggedleft}
+
+\vfill
+
+% oluselicense generates a license mark that a) licenses the result
+% under a CC-BY licence and b) acknowledges the original source (the
+% OLP).  Acknowledgment of the source is a requirement under the
+% conditions of the CC-BY license used by the OLP, but you are not
+% required to license the product itself under CC-BY.
+
+\oluselicense
+% Title of this version of the OLT with link to source
+{\href{https://github.com/OpenLogicProject/OpenLogic/tree/master/courses/sample}{\textit{Sample Logic Text}}}
+% Author of this version
+{\href{http://openlogicproject.org/}{OLP}}
+\end{titlingpage}
+
+\frontmatter
+\pagestyle{ruled}
+
+\tableofcontents*
+
+\mainmatter
+
+% olimport includes an entire part
+
+%\olimport*[sets-functions-relations]{sets-functions-relations}
+
+% you can also import individual chapters, but then don't forget to
+% include part headings
+
+\part{First-order Logic}
+
+%\olimport*[first-order-logic/introduction]{introduction}
+
+\olimport*[first-order-logic/syntax-and-semantics]{syntax}
+
+%\olimport*[first-order-logic/syntax-and-semantics]{semantics}
+
+%\olimport*[first-order-logic/models-theories]{models-theories}
+
+% For a proof system, we'll do only natural deduction. But some of the
+% texts will refer to other proof systems unless you set some tags in
+% the config.sty file.  So make sure those are set. We'll include
+% these sections by hand so we can add a couple of sections from the
+% proof-systems chapter. Of course, if new sections are added or
+% sections are moved or renamed in the main repository, this may
+% break.
+
+%\chapter{Natural Deduction}
+
+%\olimport*[first-order-logic/proof-systems]{introduction}
+
+%\olimport*[first-order-logic/proof-systems]{natural-deduction}
+
+%\olimport*[first-order-logic/natural-deduction]{rules-and-proofs}
+
+%\olimport*[first-order-logic/natural-deduction]{propositional-rules}
+
+% We'll reorder things: let's do propositional examples first and then
+% go back to quantifiers
+
+%\olimport*[first-order-logic/natural-deduction]{derivations}
+
+%\olimport*[first-order-logic/natural-deduction]{proving-things}
+
+%\olimport*[first-order-logic/natural-deduction]{quantifier-rules}
+
+%\olimport*[first-order-logic/natural-deduction]{proving-things-quant}
+
+%\olimport*[first-order-logic/natural-deduction]{proof-theoretic-notions}
+
+%\olimport*[first-order-logic/natural-deduction]{provability-consistency}
+
+%\olimport*[first-order-logic/natural-deduction]{provability-propositional}
+
+%\olimport*[first-order-logic/natural-deduction]{provability-quantifiers}
+
+%\olimport*[first-order-logic/natural-deduction]{soundness}
+
+%\olimport*[first-order-logic/natural-deduction]{identity}
+
+%\olimport*[first-order-logic/natural-deduction]{soundness-identity}
+
+% Chapters should end with \OLEndChapterHook. They will automatically
+% if you include entire parts or chapters. Here we did a chapter ``by
+% hand'' so we should add \OLEndChapterHook by hand too
+
+%\OLEndChapterHook
+
+%\olimport*[first-order-logic/completeness]{completeness}
+
+%\olimport*[first-order-logic/beyond]{beyond}
+
+% OLEndPartHook should come at the end of each
+% part.
+
+\OLEndPartHook
+
+% Include some more chapters and parts
+
+%\olimport*[turing-machines]{turing-machines}
+
+% Part: incompleteness
+
+%\part{Computability and Incompleteness}
+
+% include intro to recursive function from computability part
+
+%\olimport*[computability/recursive-functions]{recursive-functions}
+
+%\olimport*[incompleteness/arithmetization-syntax]{arithmetization-syntax}
+
+%\olimport*[incompleteness/representability-in-q]{representability-in-q}
+
+% leave out this part -- it depends on computability theory chapter
+% \olimport[incompleteness/theories-computability]{theories-computability}
+
+%\olimport*[incompleteness/incompleteness-provability]{incompleteness-provability}
+
+%\OLEndPartHook
+
+\stopproblems
+
+% Ok, that's it. Now for the appendices
+
+%\appendix
+
+%\olimport*[methods]{methods}
+
+%\olimport*[history/biographies]{biographies}
+
+% now typeset all the problems as an appendix. If you want problems at
+% the end of each chapter, delete this part and put
+% \problemsperchapter in the preamble
+
+%\chapter{Problems}
+
+%\printproblems
+
+%\backmatter
+
+% If you include any chapters from the history part, you have to print
+% the Photo Credits. 
+
+%\photocredits
+
+% Include the bibliography
+
+\bibliographystyle{\olpath/bib/natbib-oup}
+\bibliography{\olpath/bib/open-logic}
+
+\end{document}
+


### PR DESCRIPTION
1. Fixed typos in several sections of the Syntax chapter in content/first-order-logic/syntax-and-semantics/
2. Added a row for the biconditional in the table of content/first-order-logic/syntax-and-semantics/main-operator.tex