### PR TITLE
Fix a few typos in the "Theories and their Models" chapter

### DIFF
--- a/content/first-order-logic/models-theories/introduction.tex
+++ b/content/first-order-logic/models-theories/introduction.tex
@@ -85,14 +85,14 @@ an axiom system for a theory, i.e., a set of sentences.
   parallel postulate is independent of the other axioms of geometry.
 \item Another important question is that of definability of concepts
   in a theory: The choice of the language determines what the models
-  of a theory consists of.  But not every aspect of a theory must be
+  of a theory consist of.  But not every aspect of a theory must be
   represented separately in its models.  For instance, every ordering
   $\le$ determines a corresponding strict ordering~$<$---given one, we
   can define the other.  So it is not necessary that a model of a
   theory involving such an order must \emph{also} contain the
   corresponding strict ordering.  When is it the case, in general,
   that one relation can be defined in terms of others?  When is it
-  impossible to define a relation in terms of other (and hence must
+  impossible to define a relation in terms of others (and hence must
   add it to the primitives of the language)?
 \end{enumerate}
 \end{explain}

--- a/content/first-order-logic/models-theories/set-theory.tex
+++ b/content/first-order-logic/models-theories/set-theory.tex
@@ -70,7 +70,7 @@ set, we could write
 where, of course, $x \subseteq z$ would in turn have to be replaced by
 its definition.
 
-To talk about operations on sets, such has $X \cup Y$ and $\Pow{X}$, we
+To talk about operations on sets, such as $X \cup Y$ and $\Pow{X}$, we
 have to use a similar trick.  There are no function symbols in the
 language of set theory, but we can express the functional relations $X
 \cup Y = Z$ and $\Pow{X} = Y$ by

--- a/content/first-order-logic/models-theories/theories.tex
+++ b/content/first-order-logic/models-theories/theories.tex
@@ -120,11 +120,11 @@ object.  Note that in this sense ``is a part of'' resembles ``is a
 subset of,'' but does not resemble ``is an element of'' which is
 neither reflexive nor transitive.
 \begin{align*}
-& \lforall[x][\Atom{\Obj P}{x,x}], \\
+& \lforall[x][\Atom{\Obj P}{x,x}] \\
 & \lforall[x][\lforall[y][((\Part{x}{y} \land \Part{y}{x})
-      \lif \eq[x][y])]], \\
+      \lif \eq[x][y])]] \\
 & \lforall[x][\lforall[y][\lforall[z][((\Part{x}{y} \land
-        \Part{y}{z}) \lif \Part{x}{z})]]],\\
+        \Part{y}{z}) \lif \Part{x}{z})]]]\\
 \intertext{Moreover, any two objects have a mereological sum (an object that has
   these two objects as parts, and is minimal in this respect).}  &
 \lforall[x][\lforall[y][\lexists[z][\lforall[u][(\Part{z}{u} \liff

--- a/content/first-order-logic/models-theories/theories.tex
+++ b/content/first-order-logic/models-theories/theories.tex
@@ -14,11 +14,11 @@
 The theory of strict linear orders in the language~$\Lang L_<$ is
 axiomatized by the set
 \begin{align*}
-& \lforall[x][\lnot x < x], \\
+\{\quad & \lforall[x][\lnot x < x], \\
 & \lforall[x][\lforall[y][((x < y \lor y <
     x) \lor x = y)]], \\
 & \lforall[x][\lforall[y][\lforall[z][((x < y
-      \land y < z) \lif x < z)]]]
+      \land y < z) \lif x < z)]]] \quad \}
 \end{align*}
 It completely captures the intended !!{structure}s: every strict
 linear order is a model of this axiom system, and vice versa, if $R$
@@ -47,7 +47,7 @@ sentences in the language of arithmetic~$\Lang L_A$.
 & \lforall[x][\lforall[y][\eq[(x + y')][(x + y)']]]\\
 & \lforall[x][\eq[(x \times \Obj 0)][\Obj 0]]\\
 & \lforall[x][\lforall[y][\eq[(x \times y')][((x \times y) + x)]]]\\
-& \lforall[x][\lforall[y][(x < y \liff \lexists[z][\eq[(z' + x)][y])])]]\\
+& \lforall[x][\lforall[y][(x < y \liff \lexists[z][\eq[(z' + x)][y])]]]\\
 \intertext{plus all sentences of the form}
 & (!A(\Obj 0) \land \lforall[x][(!A(x) \lif !A(x'))]) \lif \lforall[x][!A(x)]
 \end{align*}


### PR DESCRIPTION
I also added a set of braces around the sentences in the "strict linear orders" example, i.e., the first example in the third section of this chapter. I did this only for the first example because the preceding text announces a set and the sentences were separated by commas but not enclosed in an explicit set. The commas are not included in the following examples, nor is the word "set" used. So I left them alone. The only exception is the mereology example, in which I removed the commas in order to be consistent with the previous examples.