### PR TITLE
Add missing label of discharged assumption in natural-deduction/provability-consistency.tex

### DIFF
--- a/content/first-order-logic/natural-deduction/derivations.tex
+++ b/content/first-order-logic/natural-deduction/derivations.tex
@@ -43,8 +43,8 @@ If !!a{derivation} of $!A$ from~$\Gamma$ exists, we say that $!A$ is
 \end{defn}
 
 \begin{ex}
-Every assumption on its own is !!a{derivation}. So, e.g., $!C$ by
-itself is !!a{derivation}, and so is $!D$ by itself.  We can obtain a
+Every assumption on its own is !!a{derivation}. So, e.g., $!A$ by
+itself is !!a{derivation}, and so is $!B$ by itself.  We can obtain a
 new !!{derivation} from these by applying, say, the $\Intro{\land}$
 rule,
 \begin{prooftree}

--- a/content/first-order-logic/natural-deduction/proof-theoretic-notions.tex
+++ b/content/first-order-logic/natural-deduction/proof-theoretic-notions.tex
@@ -19,7 +19,7 @@ and consistency for natural deduction.
 
 \begin{explain}
 Just as we've defined a number of important semantic notions
-(validity, entailment, satisfiabilty), we now define corresponding
+(validity, entailment, satisfiability), we now define corresponding
 \emph{proof-theoretic notions}.  These are not defined by appeal to
 satisfaction of !!{sentence}s in !!{structure}s, but by appeal to the
 !!{derivability} or !!{nonderivability} of certain !!{sentence}s from

--- a/content/first-order-logic/natural-deduction/provability-consistency.tex
+++ b/content/first-order-logic/natural-deduction/provability-consistency.tex
@@ -69,6 +69,7 @@ $\delta_1$ be the corresponding derivation of $\lfalse$ from
   \RightLabel{$\delta_1$}
   \DeduceC{$\lfalse$}
   \RightLabel{\FalseCl}
+  \DischargeRule{\FalseCl}{1}
   \UnaryInfC{$!A$}
 \end{prooftree}
 \end{proof}

--- a/content/first-order-logic/natural-deduction/proving-things.tex
+++ b/content/first-order-logic/natural-deduction/proving-things.tex
@@ -63,9 +63,9 @@ derivation.
 To find a logical rule that could give us this conclusion, we
 look at the logical connectives in the conclusion: $\lnot$,
 $\lor$, and $\lif$. We only care at the moment about the first
-occurence of $\lif$ because it is the !!{main operator} of the
+occurrence of $\lif$ because it is the !!{main operator} of the
 !!{sentence} in the end-sequent, while $\lnot$, $\lor$ and the second
-occurence of $\lif$ are inside the scope of another connective, so we
+occurrence of $\lif$ are inside the scope of another connective, so we
 will take care of those later. We therefore start with the
 \Intro{\lif} rule.  A correct application must look like this:
 \begin{prooftree}
@@ -81,7 +81,7 @@ of the \Intro{\lif} rule, or we can work from the top down and apply a
 $\lnot !A \lor !B$ as the leftmost premise of \Elim{\lor}.  For a valid
 application of \Elim{\lor}, the other two premises must be identical
 to the conclusion $!A \lif !B$, but each may be derived in turn from
-another assumption, namely the two disjuncts of $\lnot !A \lor !B$.
+another assumption, namely one of the two disjuncts of $\lnot !A \lor !B$.
 So our !!{derivation} will look like this:
 \begin{prooftree}
 \AxiomC{$\Discharge{\lnot !A \lor !B}{1}$}


### PR DESCRIPTION
Only one new commit: 
- Add label of discharged assumption in last derivation in proof of proposition 19 in "Derivability and Consistency"