### PR TITLE
New material on formation sequences for first-order logic and propositional logic

### DIFF
--- a/bib/open-logic.bib
+++ b/bib/open-logic.bib
@@ -1269,3 +1269,20 @@ Title = {Level Theory, part 1: Axiomatizing the bare idea of a cumulative hierar
   year = {2004},
   url = {http://http://eugeniacheng.com/wp-content/uploads/2017/02/cheng-proofguide.pdf}
 }
+
+@book{Smullyan1995,
+	author = {Smullyan, Raymond M.},
+	publisher = {Dover Publications},
+    address = {Mineola, NY},
+	title = {First-Order Logic},
+	year = {1995},
+    note = {Unabridged, corrected republication. First published by Springer-Verlag, New York, 1968}}
+
+@article{Zuckerman1973,
+	author = {Zuckerman, Martin M.},
+	journal = {Notre Dame Journal of Formal Logic},
+	number = {1},
+	pages = {134--138},
+	title = {Formation sequences for propositional formulas},
+	volume = {14},
+	year = {1973}}

--- a/content/first-order-logic/syntax-and-semantics/formation-sequences.tex
+++ b/content/first-order-logic/syntax-and-semantics/formation-sequences.tex
@@ -1,0 +1,254 @@
+% Part: first-order-logic
+% Chapter: syntax-and-semantics
+% Section: formation-sequences
+
+\documentclass[../../../include/open-logic-section]{subfiles}
+
+\begin{document}
+
+\olfileid{fol}{syn}{fseq}
+
+\olsection{Formation Sequences}
+
+Defining !!{formula}s via an inductive definition, and the
+complementary technique of proving properties of !!{formula}s via
+induction, is an elegant and efficient approach. However, it can
+also be useful to consider a more bottom-up, step-by-step approach
+to the construction of !!{formula}s, which we do here using the
+notion of a \emph{formation sequence}.
+%
+To show how terms and !!{formula}s can be introduced in this way
+without needing to refer to their inductive definitions, we first
+introduce the notion of an arbitrary string of symbols drawn from
+some language $\Lang L$.
+
+\begin{defn}[Strings]
+\ollabel{defn:string}
+Suppose $\Lang L$ is a first-order language.
+An \emph{$\Lang L$-string} is a finite sequence of symbols of
+$\Lang L$. Where the language $\Lang L$ is clearly fixed by the
+context, we will often refer to a $\Lang L$-string as a
+\emph{string} simpliciter.
+\end{defn}
+
+\begin{ex}
+For any first-order language $\Lang L$, all
+$\Lang L$-!!{formula}s are $\Lang L$-strings, but not
+conversely. For example, $)(x_0\lif\lexists$ is an
+$\Lang L$-string but not an $\Lang L$-!!{formula}.
+\end{ex}
+
+\begin{defn}[Formation sequences for terms]
+\ollabel{defn:fseq-trm}
+A finite sequence of $\Lang L$-strings $\tuple{t_0,\dotsc,t_n}$
+is a \emph{formation sequence} for a term $t$
+if $t \ident t_n$ and for all $i \leq n$, either $t_i$ is a
+variable or a constant symbol, or $\Lang L$ contains a $k$-ary
+function symbol $f$ and there exist $m_0,\dotsc,m_k < i$
+such that $t_i \ident f(t_{m_0},\dotsc,t_{m_k})$.
+\end{defn}
+
+\begin{ex}
+The sequence
+\[
+    \tuple{c_0,x_0,f^2_0(c_0,x_0),f^1_0(f^2_0(c_0,x_0))}
+\]
+is a formation sequence for the term $f^1_0(f^2_0(c_0,x_0))$, as is
+\[
+    \tuple{x_0,c_0,f^2_0(c_0,x_0),f^1_0(f^2_0(c_0,x_0))}.
+\]
+\end{ex}
+
+\begin{defn}[Formation sequences for formulas]
+\ollabel{defn:fseq-frm}
+A finite sequence of $\Lang L$-strings $\tuple{!A_0,\dotsc,!A_n}$
+is a \emph{formation sequence} for $!A$ if $!A \ident !A_n$ and
+for all $i \leq n$, either $!A_i$ is an atomic formula or there
+exist $j,k < i$ and a variable $x$ such that one of the following
+holds:
+\begin{enumerate}
+    \tagitem{prvNot}{$!A_i \ident \lnot !A_j$.}{}%
+    \tagitem{prvAnd}{$!A_i \ident (!A_j \land !A_k)$.}{}%
+    \tagitem{prvOr}{$!A_i \ident (!A_j \lor !A_k)$.}{}%
+    \tagitem{prvIf}{$!A_i \ident (!A_j \lif !A_k)$.}{}%
+    \tagitem{prvIff}{$!A_i \ident (!A_j \liff !A_k)$.}{}%
+    \tagitem{prvAll}{$!A_i \ident \lforall{x}!A_j$.}{}%
+    \tagitem{prvEx}{$!A_i \ident \lexists{x}!A_j$.}{}%
+\end{enumerate}
+\end{defn}
+
+\begin{ex}
+\[
+\tuple{
+    R(x_0),
+    S(x_1),
+    (S(x_1) \land R(x_0)),
+    \exists{x_0}(S(x_1) \land R(x_0))
+}
+\]
+is a formation sequence of
+$\exists{x_0}(S(x_1) \land \lnot R(x_0))$, as is
+\[
+\tuple{
+    R(x_0),
+    S(c_1),
+    (S(c_1) \land R(x_0)),
+    S(c_1),
+    \forall{x_1}R(x_0),
+    \exists{x_0}(S(c_1) \land R(x_0))
+}.
+\]
+%
+As can be seen from the second example, formation sequences
+may contain `junk': formulas which are redundant or do not
+contribute to the construction.
+\end{ex}
+
+\begin{prop}\ollabel{prop:formed}
+Every !!{formula}~$!A$ in $\Frm[L]$ has a formation sequence.
+\end{prop}
+
+\begin{proof}
+Suppose $!A$ is atomic. Then the sequence $\tuple{!A}$ is a
+formation sequence for $!A$.
+%
+Now suppose that $!B$ and $!C$ have formation sequences
+$\tuple{!B_0,\dotsc,!B_n}$ and $\tuple{!C_0,\dotsc,!C_m}$
+respectively.
+%
+\begin{enumerate}
+  \tagitem{prvNot}{If $!A \ident \lnot !B$,
+      then $\tuple{!B_0,\dotsc,!B_n,\lnot !B_n}$
+      is a formation sequence for $!A$.}{}
+  \tagitem{prvAnd}{If $!A \ident (!B \land !C)$,
+      then $\tuple{!B_0,\dotsc,!B_n,!C_0,\dotsc,!C_m,(!B_n \land !C_m)}$
+      is a formation sequence for $!A$.}{}
+  \tagitem{prvOr}{If $!A \ident (!B \lor !C)$,
+      then $\tuple{!B_0,\dotsc,!B_n,!C_0,\dotsc,!C_m,(!B_n \lor !C_m)}$
+      is a formation sequence for $!A$.}{}
+  \tagitem{prvIf}{If $!A \ident (!B \lif !C)$,
+      then $\tuple{!B_0,\dotsc,!B_n,!C_0,\dotsc,!C_m,(!B_n \lif !C_m)}$
+      is a formation sequence for $!A$.}{}
+  \tagitem{prvIff}{If $!A \ident (!B \liff !C)$,
+      then $\tuple{!B_0,\dotsc,!B_n,!C_0,\dotsc,!C_m,(!B_n \liff !C_m)}$
+      is a formation sequence for $!A$.}{}
+  \tagitem{prvAll}{If $!A \ident \lforall{x}!B$,
+      then $\tuple{!B_0,\dotsc,!B_n,\lforall{x}!B_n}$
+      is a formation sequence for $!A$.}{}
+  \tagitem{prvEx}{If $!A \ident \lexists{x}!B$,
+      then $\tuple{!B_0,\dotsc,!B_n,\lexists{x}!B_n}$
+      is a formation sequence for $!A$.}{}
+\end{enumerate}
+By the principle of induction on !!{formula}s,
+every !!{formula} has a formation sequence.
+\end{proof}
+
+We can also prove the converse. This is important because it shows
+that our two ways of defining formulas are equivalent: they give
+the same results. It also means that we can prove theorems about
+formulas by using ordinary induction on the length of formation
+sequences.
+
+\begin{lem}
+\ollabel{lem:fseq-init}
+Suppose that $\tuple{!A_0,\dotsc,!A_n}$ is a formation sequence
+for $!A_n$, and that $k \leq n$. Then $\tuple{!A_0,\dotsc,!A_k}$
+is a formation sequence for $!A_k$.
+\end{lem}
+
+\begin{prob}
+Prove \olref[fol][syn][fseq]{lem:fseq-init}.
+\end{prob}
+
+\begin{thm}
+\ollabel{thm:fseq-frm-equiv}
+$\Frm[L]$ is the set of all expressions (strings of symbols)
+in the language $\Lang L$ with a formation sequence.
+\end{thm}
+
+\begin{proof}
+Let $F$ be the set of all strings of symbols in the language
+$\Lang L$ that have a formation sequence. We have seen in
+\olref[fol][syn][fseq]{prop:formed} that $\Frm[L] \subseteq F$,
+so now we prove the converse.
+
+Suppose $!A$ has a formation sequence $\tuple{!A_0,\dotsc,!A_n}$.
+We prove that $!A \in \Frm[L]$ by strong induction on $n$.
+Our induction hypothesis is that every string of symbols with a
+formation sequence of length $m < n$ is in $\Frm[L]$.
+By the definition of a formation sequence, either $!A_n$ is
+atomic or there must exist $j,k < n$ such that one of the
+following is the case:
+\begin{enumerate}
+    \tagitem{prvNot}{$!A_i \ident \lnot !A_j$.}{}%
+    \tagitem{prvAnd}{$!A_i \ident (!A_j \land !A_k)$.}{}%
+    \tagitem{prvOr}{$!A_i \ident (!A_j \lor !A_k)$.}{}%
+    \tagitem{prvIf}{$!A_i \ident (!A_j \lif !A_k)$.}{}%
+    \tagitem{prvIff}{$!A_i \ident (!A_j \liff !A_k)$.}{}%
+    \tagitem{prvAll}{$!A_i \ident \lforall{x}!A_j$.}{}%
+    \tagitem{prvEx}{$!A_i \ident \lexists{x}!A_j$.}{}%
+\end{enumerate}
+Now we reason by cases. If $!A_n$ is atomic then
+$!A_n \in \Frm[L_0]$. Suppose instead that $\varphi \equiv
+(!A_j \land !A_k)$. By lemma \olref{lem:fseq-init},
+$\tuple{!A_0,\dotsc,!A_j}$ and $\tuple{!A_0,\dotsc,!A_k}$ are
+formation sequences for $!A_j$ and $!A_k$ respectively. Since
+these are proper initial subsequences of the formation sequence
+for $\varphi$, they both have length less than $n$. Therefore by
+the induction hypothesis, $!A_j$ and $!A_k$ are in $\Frm[L_0]$,
+and so by the definition of a !!{formula}, so is
+$(!A_j \land !A_k)$. The other cases follow by parallel
+reasoning.
+\end{proof}
+
+Formation sequences for terms have similar properties to those
+for formulas.
+
+\begin{prop}
+\ollabel{prop:fseq-trm-equiv}
+$\Trm[L]$ is the set of all expressions $t$ in the language
+$\Lang L$ such that there exists a (term) formation sequence
+for $t$.
+\end{prop}
+
+\begin{prob}
+Prove \olref[fol][syn][fseq]{prop:fseq-trm-equiv}.
+Hint: use a similar strategy to that used in the proof of
+\olref[fol][syn][fseq]{thm:fseq-frm-equiv}.
+\end{prob}
+
+There are two types of `junk' that can appear in formation
+sequences: repeated elements, and elements that are irrelevant
+to the construction of the formation or term. We can eliminate
+both by looking at minimal formation sequences.
+
+\begin{defn}[Minimal formation sequences]
+\ollabel{defn:minimal-fseq}
+A formation sequence $\tuple{!A_0,\dotsc,!A_n}$ for $!A$ is a
+\emph{minimal formation sequence} for $!A$
+if for every other formation sequence $s$ for $!A$, the length
+of $s$ is greater than or equal to $n+1$.
+\end{defn}
+
+\begin{prop}
+\ollabel{prop:subformula-equivs}
+The following are equivalent:
+\begin{enumerate}
+    \item $!B$ is a subformula of $!A$.
+    \item $!B$ occurs in every formation sequence of $!A$.
+    \item $!B$ occurs in a minimal formation sequence of $!A$.
+\end{enumerate}
+\end{prop}
+
+\begin{prob}
+Prove \olref[fol][syn][fseq]{prop:subformula-equivs}.
+\end{prob}
+
+\begin{explain}
+Formation sequences were introduced by Raymond Smullyan in his
+textbook \emph{First-Order Logic} \citep{Smullyan1995}.
+Additional properties of formation sequences were established by
+\citet{Zuckerman1973}.
+\end{explain}
+
+\end{document}

--- a/content/first-order-logic/syntax-and-semantics/formation-sequences.tex
+++ b/content/first-order-logic/syntax-and-semantics/formation-sequences.tex
@@ -189,8 +189,9 @@ following is the case:
     \tagitem{prvEx}{$!A_i \ident \lexists{x}!A_j$.}{}%
 \end{enumerate}
 Now we reason by cases. If $!A_n$ is atomic then
-$!A_n \in \Frm[L_0]$. Suppose instead that $\varphi \equiv
-(!A_j \land !A_k)$. By lemma \olref{lem:fseq-init},
+$!A_n \in \Frm[L_0]$. Suppose instead that
+$\varphi \equiv (!A_j \land !A_k)$. By lemma
+\olref[fol][syn][fseq]{lem:fseq-init},
 $\tuple{!A_0,\dotsc,!A_j}$ and $\tuple{!A_0,\dotsc,!A_k}$ are
 formation sequences for $!A_j$ and $!A_k$ respectively. Since
 these are proper initial subsequences of the formation sequence

--- a/content/first-order-logic/syntax-and-semantics/subformulas.tex
+++ b/content/first-order-logic/syntax-and-semantics/subformulas.tex
@@ -87,4 +87,25 @@ come ``before'' the one we are defining---in our case, when defining
 !!{subformula}s of the ``earlier'' !!{formula}s $!B$ and $!C$.
 \end{explain}
 
+\begin{prop}
+\ollabel{prop:subfrm-trans}
+Suppose $!B$ is a subformula of $!A$ and $!C$ is a subformula of $!B$.
+Then $!C$ is a subformula of $!A$. In other words, the subformula
+relation is transitive.
+\end{prop}
+
+\begin{prob}
+Prove \olref{prop:subfrm-trans}.
+\end{prob}
+
+\begin{prop}
+\ollabel{prop:count-subfrms}
+Suppose $!A$ is a formula with $n$ connectives and quantifiers.
+Then $!A$ has at most $2n+1$ subformulas.
+\end{prop}
+
+\begin{prob}
+Prove \olref{prop:count-subfrms}.
+\end{prob}
+
 \end{document}

--- a/content/first-order-logic/syntax-and-semantics/subformulas.tex
+++ b/content/first-order-logic/syntax-and-semantics/subformulas.tex
@@ -95,7 +95,7 @@ relation is transitive.
 \end{prop}
 
 \begin{prob}
-Prove \olref{prop:subfrm-trans}.
+Prove \olref[fol][syn][sbf]{prop:subfrm-trans}.
 \end{prob}
 
 \begin{prop}
@@ -105,7 +105,7 @@ Then $!A$ has at most $2n+1$ subformulas.
 \end{prop}
 
 \begin{prob}
-Prove \olref{prop:count-subfrms}.
+Prove \olref[fol][syn][sbf]{prop:count-subfrms}.
 \end{prob}
 
 \end{document}

--- a/content/first-order-logic/syntax-and-semantics/syntax-and-semantics.tex
+++ b/content/first-order-logic/syntax-and-semantics/syntax-and-semantics.tex
@@ -19,6 +19,8 @@
 
 \olimport{subformulas}
 
+\olimport{formation-sequences}
+
 \olimport{free-vars-sentences}
 
 \olimport{substitution}

--- a/content/first-order-logic/syntax-and-semantics/syntax.tex
+++ b/content/first-order-logic/syntax-and-semantics/syntax.tex
@@ -19,6 +19,8 @@
 
 \olimport{subformulas}
 
+\olimport{formation-sequences}
+
 \olimport{free-vars-sentences}
 
 \olimport{substitution}

--- a/content/first-order-logic/syntax-and-semantics/terms-formulas.tex
+++ b/content/first-order-logic/syntax-and-semantics/terms-formulas.tex
@@ -38,7 +38,7 @@ understand $\Atom{f}{t_1, \ldots, t_n}$ as just $f$ by itself if $n =
 0$.
 \end{explain}
 
-\begin{defn}[Formula]
+\begin{defn}[Formulas]
 \ollabel{defn:formulas}
 The set of \emph{!!{formula}s}~$\Frm[L]$ of the language~$\Lang L$
 is defined inductively as follows:
@@ -181,5 +181,57 @@ string~$!C$, and a closing parenthesis, in this order. If this is the
 case, then we know that the first symbol of $!A$ is an opening
 parenthesis, $!A$ contains $!B$ as a substring (starting at the second
 symbol), that substring is followed by $\lor$, etc.
+
+As terms and !!{formula}s are built up from basic elements via inductive
+definitions, we can use the following induction principles to prove
+things about them.
+
+\begin{lem}[\emph{Principle of induction on terms}]
+    \ollabel{lem:trmind}
+    Let $\Lang L$ be a first-order language.
+    If some property~$P$ holds in all of the following cases,
+    then $P(t)$ for every $t \in \Trm[L]$.
+    %
+    \begin{enumerate}
+        \item $P(v)$ for every variable $v$,
+        %
+        \item $P(a)$ for every constant symbol $a$ of $\Lang L$,
+        %
+        \item If $t_1,\dotsc,t_n \in \Trm[L]$, $f$ is an $n$-place
+            function symbol of $\Lang L$, and $P(t_1),\dotsc,P(t_n)$,
+            then $P(f(t_1,\dotsc,t_n))$.
+    \end{enumerate}
+\end{lem}
+
+\begin{prob}
+    Prove \olref[fol][syn][frm]{lem:trmind}.
+\end{prob}
+
+\begin{lem}[\emph{Principle of induction on !!{formula}s}]
+    \ollabel{thm:frmind}
+    Let $\Lang L$ be a first-order language.
+    If some property~$P$ holds for all the atomic !!{formula}s
+    and is such that
+    %
+    \begin{enumerate}
+        \item $!A$ is an atomic formula.
+        \tagitem{prvNot}{it holds for $\lnot !A$ whenever it
+            holds for~$!A$;}{}
+        \tagitem{prvAnd}{it holds for $(!A \land !B)$
+            whenever it holds for $!A$ and~$!B$;}{}
+        \tagitem{prvOr}{it holds for $(!A \lor !B)$
+            whenever it holds for $!A$ and~$!B$;}{}
+        \tagitem{prvIf}{it holds for $(!A \lif !B)$
+            whenever it holds for $!A$ and~$!B$;}{}
+        \tagitem{prvIff}{it holds for $(!A \liff !B)$
+            whenever it holds for $!A$ and~$!B$;}{}
+        \tagitem{prvEx}{it holds for $\lexists[x]!A$
+            whenever it holds for $!A$;}{}
+        \tagitem{prvAll}{it holds for $\lforall[x]!A$
+            whenever it holds for $!A$;}{}
+  \end{enumerate}
+  %
+  then $P$ holds for all formulas $!A \in \Frm[L]$.
+\end{lem}
 
 \end{document}

--- a/content/first-order-logic/syntax-and-semantics/unique-readability.tex
+++ b/content/first-order-logic/syntax-and-semantics/unique-readability.tex
@@ -67,8 +67,11 @@ formulas, the new formulas have the property provided the old ones do.
 
 Let $l(!A)$ be the number of left parentheses, and $r(!A)$ the number
 of right parentheses in~$!A$, and $l(t)$ and $r(t)$ similarly the
-number of left and right parentheses in a term~$t$.  We leave the
-proof that for any term~$t$, $l(t) = r(t)$ as an exercise.
+number of left and right parentheses in a term~$t$.
+
+\begin{prob}
+    Prove that for any term~$t$, $l(t) = r(t)$.
+\end{prob}
 
 \begin{enumerate}
 \tagitem{prvFalse}{\indcase{!A}{\lfalse}{$\indfrm$ has 0 left and 0

--- a/content/propositional-logic/syntax-and-semantics/formation-sequences.tex
+++ b/content/propositional-logic/syntax-and-semantics/formation-sequences.tex
@@ -1,0 +1,149 @@
+% Part: first-order-logic
+% Chapter: syntax-and-semantics
+% Section: formation-sequences
+
+\documentclass[../../../include/open-logic-section]{subfiles}
+
+\begin{document}
+
+\olfileid{pl}{syn}{fseq}
+
+\olsection{Formation Sequences}
+
+Defining !!{formula}s via an inductive definition, and the
+complementary technique of proving properties of !!{formula}s via
+induction, is an elegant and efficient approach. However, it can
+also be useful to consider a more bottom-up, step-by-step approach
+to the construction of !!{formula}s, which we do here using the
+notion of a \emph{formation sequence}.
+
+\begin{defn}[Formation sequences for formulas]
+\ollabel{defn:fseq-frm}
+A finite sequence $\tuple{!A_0,\dotsc,!A_n}$ of strings of
+symbols from the language $\Lang L_0$ is a \emph{formation
+sequence} for $!A$ if $!A \ident !A_n$ and for all $i \leq n$,
+either $!A_i$ is an atomic formula or there exist $j,k < i$ and
+a variable $x$ such that one of the following holds:
+\begin{enumerate}
+    \tagitem{prvNot}{$!A_i \ident \lnot !A_j$.}{}%
+    \tagitem{prvAnd}{$!A_i \ident (!A_j \land !A_k)$.}{}%
+    \tagitem{prvOr}{$!A_i \ident (!A_j \lor !A_k)$.}{}%
+    \tagitem{prvIf}{$!A_i \ident (!A_j \lif !A_k)$.}{}%
+    \tagitem{prvIff}{$!A_i \ident (!A_j \liff !A_k)$.}{}%
+\end{enumerate}
+\end{defn}
+
+\begin{ex}
+\[
+\tuple{
+    \Obj p_0,
+    \Obj p_1,
+    (\Obj p_1 \land \Obj p_0),
+    \lnot (\Obj p_1 \land \Obj p_0)
+}
+\]
+is a formation sequence of
+$\lnot (\Obj p_1 \land \Obj p_0)$, as is
+\[
+\tuple{
+    \Obj p_0,
+    \Obj p_1,
+    \Obj p_0,
+    (\Obj p_1 \land \Obj p_0),
+    (\Obj p_0 \lif \Obj p_1),
+    \lnot (\Obj p_1 \land \Obj p_0)
+}.
+\]
+%
+As can be seen from the second example, formation sequences
+may contain `junk': formulas which are redundant or do not
+contribute to the construction.
+\end{ex}
+
+\begin{prop}
+\ollabel{prop:formed}
+Every !!{formula}~$!A$ in $\Frm[L_0]$ has a formation sequence.
+\end{prop}
+
+\begin{proof}
+Suppose $!A$ is atomic. Then the sequence $\tuple{!A}$ is a
+formation sequence for $!A$.
+%
+Now suppose that $!B$ and $!C$ have formation sequences
+$\tuple{!B_0,\dotsc,!B_n}$ and $\tuple{!C_0,\dotsc,!C_m}$
+respectively.
+%
+\begin{enumerate}
+  \tagitem{prvNot}{If $!A \ident \lnot !B$,
+      then $\tuple{!B_0,\dotsc,!B_n,\lnot !B_n}$
+      is a formation sequence for $!A$.}{}
+  \tagitem{prvAnd}{If $!A \ident (!B \land !C)$,
+      then $\tuple{!B_0,\dotsc,!B_n,!C_0,\dotsc,!C_m,(!B_n \land !C_m)}$
+      is a formation sequence for $!A$.}{}
+  \tagitem{prvOr}{If $!A \ident (!B \lor !C)$,
+      then $\tuple{!B_0,\dotsc,!B_n,!C_0,\dotsc,!C_m,(!B_n \lor !C_m)}$
+      is a formation sequence for $!A$.}{}
+  \tagitem{prvIf}{If $!A \ident (!B \lif !C)$,
+      then $\tuple{!B_0,\dotsc,!B_n,!C_0,\dotsc,!C_m,(!B_n \lif !C_m)}$
+      is a formation sequence for $!A$.}{}
+  \tagitem{prvIff}{If $!A \ident (!B \liff !C)$,
+      then $\tuple{!B_0,\dotsc,!B_n,!C_0,\dotsc,!C_m,(!B_n \liff !C_m)}$
+      is a formation sequence for $!A$.}{}
+\end{enumerate}
+By the principle of induction on !!{formula}s,
+every !!{formula} has a formation sequence.
+\end{proof}
+
+We can also prove the converse. This is important because it shows
+that our two ways of defining formulas are equivalent: they give
+the same results. It also means that we can prove theorems about
+formulas by using ordinary induction on the length of formation
+sequences.
+
+\begin{lem}
+\ollabel{lem:fseq-init}
+Suppose that $\tuple{!A_0,\dotsc,!A_n}$ is a formation sequence
+for $!A_n$, and that $k \leq n$. Then $\tuple{!A_0,\dotsc,!A_k}$
+is a formation sequence for $!A_k$.
+\end{lem}
+
+\begin{thm}
+\ollabel{thm:fseq-frm-equiv}
+$\Frm[L_0]$ is the set of all expressions (strings of symbols)
+in the language $\Lang L_0$ with a formation sequence.
+\end{thm}
+
+\begin{proof}
+Let $F$ be the set of all strings of symbols in the language
+$\Lang L_0$ that have a formation sequence. We have seen in
+\olref[pl][syn][fseq]{prop:formed} that $\Frm[L_0] \subseteq F$,
+so now we prove the converse.
+
+Suppose $!A$ has a formation sequence $\tuple{!A_0,\dotsc,!A_n}$.
+We prove that $!A \in \Frm[L_0]$ by strong induction on $n$.
+Our induction hypothesis is that every string of symbols with a
+formation sequence of length $m < n$ is in $\Frm[L_0]$.
+By the definition of a formation sequence, either $!A_n$ is
+atomic or there must exist $j,k < n$ such that one of the
+following is the case:
+\begin{enumerate}
+    \tagitem{prvNot}{$!A_i \ident \lnot !A_j$.}{}%
+    \tagitem{prvAnd}{$!A_i \ident (!A_j \land !A_k)$.}{}%
+    \tagitem{prvOr}{$!A_i \ident (!A_j \lor !A_k)$.}{}%
+    \tagitem{prvIf}{$!A_i \ident (!A_j \lif !A_k)$.}{}%
+    \tagitem{prvIff}{$!A_i \ident (!A_j \liff !A_k)$.}{}%
+\end{enumerate}
+Now we reason by cases. If $!A_n$ is atomic then
+$!A_n \in \Frm[L_0]$. Suppose instead that $\varphi \equiv
+(!A_j \land !A_k)$. By lemma \olref[pl][syn][fseq]{lem:fseq-init},
+$\tuple{!A_0,\dotsc,!A_j}$ and $\tuple{!A_0,\dotsc,!A_k}$ are
+formation sequences for $!A_j$ and $!A_k$ respectively. Since
+these are proper initial subsequences of the formation sequence
+for $\varphi$, they both have length less than $n$. Therefore by
+the induction hypothesis, $!A_j$ and $!A_k$ are in $\Frm[L_0]$,
+and so by the definition of a !!{formula}, so is
+$(!A_j \land !A_k)$. The other cases follow by parallel
+reasoning.
+\end{proof}
+
+\end{document}

--- a/content/propositional-logic/syntax-and-semantics/preliminaries.tex
+++ b/content/propositional-logic/syntax-and-semantics/preliminaries.tex
@@ -43,7 +43,7 @@
    as many left parentheses as right ones.
 \end{prop}
 
-\begin{prob} 
+\begin{prob}
 Prove \olref[pl][syn][pre]{prop:balanced}
 \end{prob}
 

--- a/content/propositional-logic/syntax-and-semantics/syntax-and-semantics.tex
+++ b/content/propositional-logic/syntax-and-semantics/syntax-and-semantics.tex
@@ -19,6 +19,8 @@
 
 \olimport{preliminaries}
 
+\olimport{formation-sequences}
+
 \olimport{valuations-sat}
 
 \olimport{semantic-notions}


### PR DESCRIPTION
New material on formation sequences for first-order logic and propositional logic, based on what can be found in Smullyan and more recent textbooks like van Dalen.