### PR TITLE
Fix a few typos in the PL and FOL chapters

### DIFF
--- a/content/first-order-logic/syntax-and-semantics/subformulas.tex
+++ b/content/first-order-logic/syntax-and-semantics/subformulas.tex
@@ -40,7 +40,7 @@ of $!A$ are defined inductively as follows:
 
 \begin{defn}[Proper !!^{subformula}]
 If $!A$ is !!a{formula}, the \emph{proper !!{subformula}s}
-of $!A$ are recursively as follows:
+of $!A$ are defined recursively as follows:
 \begin{enumerate}
 \item Atomic !!{formula}s have no proper !!{subformula}s.
 

--- a/content/propositional-logic/syntax-and-semantics/formation-sequences.tex
+++ b/content/propositional-logic/syntax-and-semantics/formation-sequences.tex
@@ -22,8 +22,8 @@ notion of a \emph{formation sequence}.
 A finite sequence $\tuple{!A_0,\dotsc,!A_n}$ of strings of
 symbols from the language~$\Lang L_0$ is a \emph{formation
 sequence} for $!A$ if $!A \ident !A_n$ and for all $i \leq n$,
-either $!A_i$ is an atomic formula or there exist $j,k < i$ and
-a variable~$x$ such that one of the following holds:
+either $!A_i$ is an atomic formula or there exist $j,k < i$
+such that one of the following holds:
 \begin{enumerate}
     \tagitem{prvNot}{$!A_i \ident \lnot !A_j$.}{}%
     \tagitem{prvAnd}{$!A_i \ident (!A_j \land !A_k)$.}{}%

--- a/content/propositional-logic/syntax-and-semantics/valuations-sat.tex
+++ b/content/propositional-logic/syntax-and-semantics/valuations-sat.tex
@@ -10,7 +10,7 @@
 
 \olsection{\usetoken{P}{valuation} and Satisfaction}
 
-\begin{defn}[!!^{valuation}s] 
+\begin{defn}[!!^{valuation}s]
 Let $\{\True, \False\}$ be the set of the two truth values, ``true''
 and ``false.'' A \emph{!!{valuation}} for $\Lang{L_0}$ is a
 function~$\pAssign{v}$ assigning either $\True$ or $\False$ to the
@@ -24,30 +24,30 @@ function~$\pAssign{v}$ assigning either $\True$ or $\False$ to the
   \begin{align*}
     \iftag{prvFalse}{\pValue{v}(\lfalse) & = \False; \\}{}
     \iftag{prvTrue}{\pValue{v}(\ltrue) & = \True; \\}{}
-    \pValue{v}(\Obj p_n) & = \pAssign{v}(\Obj p_n); \\ 
+    \pValue{v}(\Obj p_n) & = \pAssign{v}(\Obj p_n); \\
     \iftag{prvNot}{\pValue{v}(\lnot !A) & = \begin{cases}
-        \True & \text{if } \pValue{v}(!A) = \False;\\ 
-        \False & \text{otherwise.} 
+        \True & \text{if } \pValue{v}(!A) = \False;\\
+        \False & \text{otherwise.}
       \end{cases} \\ }{}
-    \iftag{prvAnd}{\pValue{v}(!A \land !B) & = \begin{cases} 
+    \iftag{prvAnd}{\pValue{v}(!A \land !B) & = \begin{cases}
         \True &
         \text{if $\pValue{v}(!A) = \True$ and $\pValue{v}(!B) = \True$;}\\
         \False &
         \text{if $\pValue{v}(!A) = \False$ or $\pValue{v}(!B) = \False$}.
       \end{cases}\\}{}
-    \iftag{prvOr}{\pValue{v}(!A \lor !B) & = \begin{cases} 
+    \iftag{prvOr}{\pValue{v}(!A \lor !B) & = \begin{cases}
         \True &
         \text{if $\pValue{v}(!A) = \True$ or $\pValue{v}(!B) = \True$;}\\
         \False &
         \text{if $\pValue{v}(!A) = \False$ and $\pValue{v}(!B) = \False$}.
       \end{cases}\\}{}
-    \iftag{prvIf}{\pValue{v}(!A \lif !B) & = \begin{cases} 
+    \iftag{prvIf}{\pValue{v}(!A \lif !B) & = \begin{cases}
         \True &
         \text{if $\pValue{v}(!A) = \False$ or $\pValue{v}(!B) = \True$;}\\
         \False &
         \text{if $\pValue{v}(!A) = \True$ and $\pValue{v}(!B) = \False$}.
       \end{cases}\\}{}
-    \iftag{prvIff}{\pValue{v}(!A \liff !B) & = \begin{cases} 
+    \iftag{prvIff}{\pValue{v}(!A \liff !B) & = \begin{cases}
         \True &
         \text{if $\pValue{v}(!A) = \pValue{v}(!B)$;}\\
         \False &
@@ -56,71 +56,71 @@ function~$\pAssign{v}$ assigning either $\True$ or $\False$ to the
 \end{align*}
 \end{defn}
 
-\begin{explain} 
+\begin{explain}
 The clauses correspond to the following truth tables:
 \begin{center}
 \iftag{prvNot}{
-  \begin{tabular}{|c||c|} \hline 
-    $!A$ & $ \lnot !A$ \\ 
-    \hline \hline 
-    $\True$ & $\False$ \\ 
-    $\False$ & $\True$ \\ 
-    \hline 
+  \begin{tabular}{|c||c|} \hline
+    $!A$ & $ \lnot !A$ \\
+    \hline \hline
+    $\True$ & $\False$ \\
+    $\False$ & $\True$ \\
+    \hline
   \end{tabular}
 }{}
 \iftag{prvAnd}{
-  \begin{tabular}{|cc||c|} \hline 
-    $!A$ & $!B$ & $!A \land !B$ \\ 
-    \hline \hline 
-    $\True$ & $\True$ & $\True$ \\ 
-    $\True$ & $\False$ & $\False$ \\ 
+  \begin{tabular}{|cc||c|} \hline
+    $!A$ & $!B$ & $!A \land !B$ \\
+    \hline \hline
+    $\True$ & $\True$ & $\True$ \\
+    $\True$ & $\False$ & $\False$ \\
     $\False$ & $\True$ & $\False$ \\
-    $\False$ & $\False$ & $\False$ \\ 
-    \hline 
+    $\False$ & $\False$ & $\False$ \\
+    \hline
   \end{tabular}
 }{}
 \iftag{prvOr}{
-  \begin{tabular}{|cc||c|} \hline 
-    $!A$ & $!B$ & $!A \lor !B$ \\ 
-    \hline \hline 
-    $\True$ & $\True$ & $\True$ \\ 
-    $\True$ & $\False$ & $\True$ \\ 
+  \begin{tabular}{|cc||c|} \hline
+    $!A$ & $!B$ & $!A \lor !B$ \\
+    \hline \hline
+    $\True$ & $\True$ & $\True$ \\
+    $\True$ & $\False$ & $\True$ \\
     $\False$ & $\True$ & $\True$ \\
-    $\False$ & $\False$ & $\False$ \\ 
-    \hline 
+    $\False$ & $\False$ & $\False$ \\
+    \hline
   \end{tabular}
 }{}%
 \iftag{notprvNot,notprvAnd,notprvOr,notprvIf}{}{\\[1em]}
 \iftag{prvIf}{
-  \begin{tabular}{|cc||c|} \hline 
-    $!A$ & $!B$ & $!A \lif !B$ \\ 
-    \hline \hline 
-    $\True$ & $\True$ & $\True$ \\ 
-    $\True$ & $\False$ & $\False$ \\ 
+  \begin{tabular}{|cc||c|} \hline
+    $!A$ & $!B$ & $!A \lif !B$ \\
+    \hline \hline
+    $\True$ & $\True$ & $\True$ \\
+    $\True$ & $\False$ & $\False$ \\
     $\False$ & $\True$ & $\True$ \\
-    $\False$ & $\False$ & $\True$ \\ 
-    \hline 
+    $\False$ & $\False$ & $\True$ \\
+    \hline
   \end{tabular}
 }{}
 \iftag{prvIff}{
-  \begin{tabular}{|cc||c|} \hline 
-    $!A$ & $!B$ & $!A \liff !B$ \\ 
-    \hline \hline 
-    $\True$ & $\True$ & $\True$ \\ 
-    $\True$ & $\False$ & $\False$ \\ 
+  \begin{tabular}{|cc||c|} \hline
+    $!A$ & $!B$ & $!A \liff !B$ \\
+    \hline \hline
+    $\True$ & $\True$ & $\True$ \\
+    $\True$ & $\False$ & $\False$ \\
     $\False$ & $\True$ & $\False$ \\
-    $\False$ & $\False$ & $\True$ \\ 
-    \hline 
+    $\False$ & $\False$ & $\True$ \\
+    \hline
   \end{tabular}
 }{}
-\end{center} 
+\end{center}
 \end{explain}
 
 \begin{prob}
-Consider adding to $\Lang{L_0}$ a ternary connective $\diamondsuit$ 
-with evaluation given by 
+Consider adding to $\Lang{L_0}$ a ternary connective $\diamondsuit$
+with evaluation given by
 \begin{gather*}
-  \pValue{v}(\diamondsuit( !A , !B , !C ) ) = \begin{cases} 
+  \pValue{v}(\diamondsuit( !A , !B , !C ) ) = \begin{cases}
     \pValue{v}( !B ) &
     \text{if $\pValue{v}(!A) = \True$;}\\
     \pValue{v}( !C ) &
@@ -130,7 +130,7 @@ with evaluation given by
 Write down the truth table for this connective.
 \end{prob}
 
-\begin{thm} [Local Determination] 
+\begin{thm}[Local Determination]
 \ollabel{thm:LocalDetermination} Suppose that $\pAssign{v_1}$ and
 $\pAssign{v_2}$ are !!{valuation}s that agree on the propositional
 letters occurring in $!A$, i.e., $\pAssign{v_1}(\Obj p_n) =
@@ -139,16 +139,15 @@ letters occurring in $!A$, i.e., $\pAssign{v_1}(\Obj p_n) =
 on~$!A$, i.e., $\pValue{v_1}(!A) = \pValue{v_2}(!A)$.
 \end{thm}
 
-\begin{proof} 
-By induction on $!A$. 
+\begin{proof}
+By induction on $!A$.
 \end{proof}
 
 \begin{defn}[Satisfaction]
-\ollabel{defn:satisfaction} Using the evaluation function, we can
-define the notion of \emph{satisfaction of !!a{formula}~$!A$ by
-  !!a{valuation}~$\pAssign{v}$}, $\pSat{v}{!A}$, inductively as
-  follows. (We write $\pSat/{v}{!A}$ to mean ``not
-  $\pSat{v}{!A}$.'')
+\ollabel{defn:satisfaction} We can inductively define the notion of
+  \emph{satisfaction of !!a{formula}~$!A$ by
+  !!a{valuation}~$\pAssign{v}$}, $\pSat{v}{!A}$, as follows.
+  (We write $\pSat/{v}{!A}$ to mean ``not $\pSat{v}{!A}$.'')
 \begin{enumerate}
 \tagitem{prvFalse}{%
   \indcase{!A}{\lfalse}{$\pSat/{v}{\indfrm}$.}}{}

--- a/content/propositional-logic/syntax-and-semantics/valuations-sat.tex
+++ b/content/propositional-logic/syntax-and-semantics/valuations-sat.tex
@@ -134,7 +134,9 @@ Write down the truth table for this connective.
 \ollabel{thm:LocalDetermination} Suppose that $\pAssign{v_1}$ and
 $\pAssign{v_2}$ are !!{valuation}s that agree on the propositional
 letters occurring in $!A$, i.e., $\pAssign{v_1}(\Obj p_n) =
-\pAssign{v_2}(\Obj p_n)$ whenever $\Obj p_n$ occurs in some !!{formula}~$!A$. Then $\pValue{v_1}$ and $\pValue{v_2}$ also agree on~$!A$, i.e., $\pValue{v_1}(!A) = \pValue{v_2}(!A)$.
+\pAssign{v_2}(\Obj p_n)$ whenever $\Obj p_n$ occurs in some
+!!{formula}~$!A$. Then $\pValue{v_1}$ and $\pValue{v_2}$ also agree
+on~$!A$, i.e., $\pValue{v_1}(!A) = \pValue{v_2}(!A)$.
 \end{thm}
 
 \begin{proof} 


### PR DESCRIPTION
The only substantive change is to remove the wording "Using the evaluation function" from the definition of satisfaction in PL, since the definition does not use the evaluation function (and its connection to the satisfaction relation is given immediately afterwards by a proposition, not by a definition).