### PR TITLE
Fix typos in chapter about filtrations in modal logic

### DIFF
--- a/content/normal-modal-logic/filtrations/filtrations-def.tex
+++ b/content/normal-modal-logic/filtrations/filtrations-def.tex
@@ -66,9 +66,9 @@ V(p)$.
   applies to the sub-!!{formula}s of~$!A$.
   \begin{enumerate}
     \tagitem{prvFalse}{\indcase{!A}{\lfalse}{Neither
-        $\mSat{M}{\indfrm}[w]$ nor $\mSat{M^*}{\indfrm}[w]$.}}{}
+        $\mSat{M}{\indfrm}[w]$ nor $\mSat{M^*}{\indfrm}[{[w]}]$.}}{}
     \tagitem{prvTrue}{\indcase{!A}{\ltrue}{Both
-        $\mSat{M}{\indfrm}[w]$ and $\mSat{M^*}{\indfrm}[w]$.}}{}
+        $\mSat{M}{\indfrm}[w]$ and $\mSat{M^*}{\indfrm}[{[w]}]$.}}{}
     \item \indcase{!A}{p}{The left-to-right direction is immediate, as
       $\mSat{M}{\indfrm}[w]$ only if $w \in V(p)$, which implies $[w]
       \in V^*(p)$, i.e., $\mSat{M^*}{\indfrm}[{[w]}]$. Conversely,

--- a/content/normal-modal-logic/filtrations/filtrations-def.tex
+++ b/content/normal-modal-logic/filtrations/filtrations-def.tex
@@ -132,7 +132,7 @@ V(p)$.
           \olref{defn:filtration}\olref{defn:filtration-R1}, we have
           $R^*[w][v]$, so that $\mSat{M^*}{!B}[{[v]}]$; by inductive
           hypothesis $\mSat{M}{!B}[v]$, and since $v$ was arbitrary,
-          $\mSat{M}{\indfrm}[u]$.}}}{}
+          $\mSat{M}{\indfrm}[w]$.}}}{}
     
     \tagitem{prvDiamond}{\iftag{probDiamond}{Exercise.}{\indcase{!A}{\Diamond
           !B}{Suppose $\mSat{M}{\indfrm}[w]$. Then for some $v \in W$,

--- a/content/normal-modal-logic/filtrations/more-filtrations.tex
+++ b/content/normal-modal-logic/filtrations/more-filtrations.tex
@@ -70,7 +70,7 @@ $C_1(u,v)$ and $C_2(u,v)$ than $C_1(u,v)$ alone.
 \end{table}
 
 \begin{thm}\ollabel{thm:more-filtrations}
-  Let $\mModel{M} =\tuple{W,R,P}$ be a model, $\Gamma$ closed under
+  Let $\mModel{M} =\tuple{W,R,V}$ be a model, $\Gamma$ closed under
   sub-!!{formula}s. Let $W^*$ and $V^*$ be defined as in
   \olref[fil]{defn:filtration}. Then:
   \begin{enumerate}


### PR DESCRIPTION
Another student pointed out these typos to me.
* Points in a filtration are equivalence classes. And in some places, the brackets that mark the equivalence class were missing.
* Once the wrong variable is used. (`u` does not even appear in this proof)
* Finally, the parts of a model are introduced with a non-conventional variable.