### PR TITLE
Format set axioms

### DIFF
--- a/content/set-theory/z/pairs.tex
+++ b/content/set-theory/z/pairs.tex
@@ -8,11 +8,13 @@
 The next axiom to consider is the following:
 
 \begin{axiom}[Pairs]
-For any sets $a, b$, the set $\{a, b\}$ exists.\\
-	$\forall a \forall b \exists P \forall x (x \in P \liff (x = a \lor x = b))$
+For any sets $a, b$, the set $\{a, b\}$ exists.
+\[
+	\forall a \forall b \exists P \forall x (x \in P \liff (x = a \lor x = b))
+\]
 \end{axiom}
 
-Here is how to justify this axiom, using the iterative conception. Suppose $a$ is available at stage $S$, and $b$ is available at stage $T$. Let $M$ be whichever of stages $S$ and $T$ comes later. Then since $a$ and $b$ are both available at stage $M$, the set $\{a,b\}$ is a possible collection available at any stage after $M$ (whichever is the greater). 
+Here is how to justify this axiom, using the iterative conception. Suppose $a$ is available at stage $S$, and $b$ is available at stage $T$. Let $M$ be whichever of stages $S$ and $T$ comes later. Then since $a$ and $b$ are both available at stage $M$, the set $\{a,b\}$ is a possible collection available at any stage after $M$ (whichever is the greater).
 
 But hold on!{} Why assume that there \emph{are} any stages after $M$? If there are none, then our justification will fail. So, to justify Pairs, we will have to add another principle to the story we told in \olref[sth][z][story]{sec}, namely:
 \begin{enumerate}
@@ -37,10 +39,10 @@ For any sets $a$ and $b$, the following sets exist:
 
 \begin{proof}
 \olref{singleton}. By Pairs, $\{a, a\}$ exists, which is $\{a\}$ by
-Extensionality. 
+Extensionality.
 
 \olref{binunion}. By Pairs, $\{a, b\}$ exists. Now $a \cup b = \bigcup
-\{a, b\}$ exists by Union. 
+\{a, b\}$ exists by Union.
 
 \olref{tuples}. By \olref{singleton}, $\{a\}$ exists. By Pairs, $\{a,
 b\}$ exists. Now $\{\{a\}, \{a, b\}\} = \tuple{a, b}$ exists, by Pairs

--- a/content/set-theory/z/powerset.tex
+++ b/content/set-theory/z/powerset.tex
@@ -8,8 +8,10 @@
 We will proceed with another axiom:
 
 \begin{axiom}[Powersets]
-For any set $A$, the set $\Pow{A} = \Setabs{x}{x \subseteq A}$ exists.\\
-		$\forall A \exists P \forall x(x \in P \liff (\forall z \in x)z \in A)$
+For any set $A$, the set $\Pow{A} = \Setabs{x}{x \subseteq A}$ exists.
+\[
+	\forall A \exists P \forall x(x \in P \liff (\forall z \in x)z \in A)
+\]
 \end{axiom}
 
 Our justification for this is pretty straightforward. Suppose $A$ is
@@ -19,7 +21,7 @@ Separation, every subset of $A$ is formed by stage $S$. So they are
 all available, to be formed into a single set, at any stage after $S$.
 And we know that there is some such stage, since $S$ is not the last
 stage (by \stagessucc). So $\Pow{A}$ exists.
-	
+
 Here is a nice consequence of Powersets:
 
 \begin{prop}\label{thm:Products}
@@ -43,7 +45,7 @@ In this proof, Powerset interacts with Separation. And that is no
 surprise. Without Separation, Powersets wouldn't be a very
 \emph{powerful} principle. After all, Separation tells us which
 subsets of a set exist, and hence determines just how ``fat'' each
-Powerset is.  
+Powerset is.
 
 \begin{prob}
 Show that, for any sets $A, B$: (i) the set of all relations with

--- a/content/set-theory/z/separation.tex
+++ b/content/set-theory/z/separation.tex
@@ -37,14 +37,14 @@ formed at stage~$S$, all of $A$'s members were formed before stage $S$
 (by \stagesacc). Now in particular, consider all the sets which are
 members of $A$ and which also satisfy $\phi$; clearly all of these
 sets, too, were formed before stage~$S$. So they are formed into a set
-$\Setabs{x \in A}{\phi(x)}$ at stage~$S$ too (by \stagesacc). 
+$\Setabs{x \in A}{\phi(x)}$ at stage~$S$ too (by \stagesacc).
 
 Unlike Na\"ive Comprehension, this avoid Russell's Paradox. For we
 cannot simply assert the existence of the set $\Setabs{x}{x \notin
 x}$. Rather, \emph{given} some set~$A$, we can assert the existence of
 the set $R_A = \Setabs{x \in A}{x \notin x}$. But all this proves is
 that $R_A \notin R_A$ and $R_A \notin A$, none of which is very
-worrying. 
+worrying.
 
 However, Separation has an immediate and striking consequence:
 
@@ -99,7 +99,7 @@ If $A \neq \emptyset$, then $\bigcap A = \Setabs{x}{(\forall y \in A)x \in y}$ e
 \begin{proof}
 Let $A \neq \emptyset$, so there is some $c \in A$. Then $\bigcap A =
 \Setabs{x}{(\forall y \in A)x \in y} = \Setabs{x \in c}{(\forall y \in
-A)x \in y}$, which exists by Separation. 
+A)x \in y}$, which exists by Separation.
 \end{proof}
 
 Note the condition that $A \neq \emptyset$, though; for $\bigcap

--- a/content/set-theory/z/union.tex
+++ b/content/set-theory/z/union.tex
@@ -10,8 +10,10 @@ But if we want arbitrary unions to exist, we need to lay down another
 axiom:
 
 \begin{axiom}[Union] For any set $A$, the set $\bigcup A =
-\Setabs{x}{(\exists b \in A) x \in b}$ exists.\\
-	$\forall A \exists U \forall x(x \in U \liff (\exists b \in A)x \in b)$
+\Setabs{x}{(\exists b \in A) x \in b}$ exists.
+\[
+	\forall A \exists U \forall x(x \in U \liff (\exists b \in A)x \in b)
+\]
 \end{axiom}
 
 This axiom is also justified by the cumulative-iterative conception.


### PR DESCRIPTION
- Use display math mode instead of inline mode for set axioms
- Remove trailing whitespace

---

I didn't update the formatting for the axiom of infinity because I don't know what's the project's preferred environment for multiline math, but that one is also typeset incorrectly.