### PR TITLE
Fixed "total order" definitions; fixed several typos.

### DIFF
--- a/content/set-theory/ordinals/iso.tex
+++ b/content/set-theory/ordinals/iso.tex
@@ -53,7 +53,7 @@ f(a)$.
 
 Generalising, $(\forall x \in B)(x \lessdot f(a) \liff x \lessdot
 g(a))$. It follows that $f(a) = g(a)$ by
-\olref[sfr][rel][ord]{prop:extensionality-totalorders}. So $(\forall
+\olref[sfr][rel][ord]{prop:extensionality-strictlinearorders}. So $(\forall
 a \in A)f(a) = g(a)$ by \olref[wo]{propwoinduction}.
 \end{proof}\noindent 
 This gives some sense that well-orderings are robust. But to continue
@@ -79,7 +79,7 @@ For reductio, suppose $f \colon A \to A_a$ is an isomorphism. Since
 $f$ is a bijection and $A_a \subsetneq A$, using \olref[wo]{wo:strictorder} let $b \in A$ be the
 $<$-least !!{element} of $A$ such that $b \neq f(b)$. We'll show that
 $(\forall x \in A)(x<b \liff x < f(b))$, from which it will follow by
-\olref[sfr][rel][ord]{prop:extensionality-totalorders} that $b =
+\olref[sfr][rel][ord]{prop:extensionality-strictlinearorders} that $b =
 f(b)$, completing the reductio.
 
 Suppose $x < b$. So $x = f(x)$, by the choice of $b$. And $f(x) <

--- a/content/sets-functions-relations/arithmetization/checking-details.tex
+++ b/content/sets-functions-relations/arithmetization/checking-details.tex
@@ -102,15 +102,15 @@ But our task is not over. As well as defining addition and
 multiplication over $\Int$, we defined an ordering relation, $\leq$,
 and we must check that this behaves as it should. In more detail, we
 must show that $\Int$ constitutes an \emph{ordered} ring.\footnote{Recall
-	from \olref[sfr][rel][ord]{def:strictlinearorder} that a total ordering
-	is a relation which is reflexive, transitive, and connected. In the
-	context of order relations, connectedness is sometimes called
+	from \olref[sfr][rel][ord]{def:linearorder} that a total order
+	is a relation which is reflexive, transitive, anti-symmetric, and connected. 
+	In the context of order relations, connectedness is sometimes called
 	\emph{trichotomy}, since for any $a$ and $b$ we have $a \leq b \lor a
 	= b \lor a \geq b$.} 
 
 \begin{defn}
 An \emph{ordered ring} is a commutative ring which is also equipped
-with a total ordering relation, $\leq$, such that:
+with a total order relation, $\leq$, such that:
 \begin{align*}
 	a \leq b &\lif a + c \leq b + c\\
 	(a \leq b \land 0 \leq c) &\lif a \times c \leq b \times c

--- a/content/sets-functions-relations/relations/orders.tex
+++ b/content/sets-functions-relations/relations/orders.tex
@@ -29,7 +29,7 @@ A preorder which is also anti-symmetric is called a
 \emph{partial order}.
 \end{defn}
 
-\begin{defn}[Linear order]
+\begin{defn}[Linear order]\ollabel{def:linearorder}
 A partial order which is also connected is called a
 \emph{total order} or \emph{linear order.}
 \end{defn}
@@ -73,9 +73,9 @@ A \emph{strict order} is a relation which is irreflexive, asymmetric,
 and transitive.
 \end{defn}
 
-\begin{defn}[Strict linear order]
-A strict order which is also connected is called a
-\emph{strict linear order.}
+\begin{defn}[Strict linear order]\ollabel{def:strictlinearorder}
+A strict order which is also connected is called a 
+\emph{strict total order} or \emph{strict linear order.}
 \end{defn}
 
 \begin{ex}
@@ -83,11 +83,6 @@ $\le$ is the linear order corresponding to the strict linear
 order~$<$. $\subseteq$ is the partial order corresponding to the
 strict order~$\subsetneq$.
 \end{ex}
-
-\begin{defn}[Total order]\ollabel{def:strictlinearorder}
-A strict order which is also connected is called a \emph{total order}.
-This is also sometimes called a \emph{strict linear order}. 
-\end{defn}
 
 Any strict order $R$ on~$A$ can be turned into a partial order by
 adding the diagonal $\Id{A}$, i.e., adding all the pairs~$\tuple{x,
@@ -97,42 +92,42 @@ by removing~$\Id{A}$. These next two results make this precise.
 
 \begin{prop}\ollabel{prop:stricttopartial}
 If $R$ is a strict order on~$A$, then $R^+ = R \cup \Id{A}$ is a
-partial order. Moreover, if $R$ is total, then $R^+$ is a linear
-order.
+partial order. Moreover, if $R$ is a strict linear order, then $R^+$ is 
+a linear order.
 \end{prop}
 
 \begin{proof}
 Suppose $R$ is a strict order, i.e., $R \subseteq A^2$ and $R$ is
 irreflexive, asymmetric, and transitive. Let $R^+ = R \cup \Id{A}$. We
-have to show that $R^+$ is reflexive, antisymmetric, and transitive.
+have to show that $R^+$ is reflexive, anti-symmetric, and transitive.
 
 $R^+$ is clearly reflexive, since $\tuple{x, x} \in \Id{A} \subseteq
 R^+$ for all $x \in A$. 
 
-To show $R^+$ is antisymmetric, suppose for reductio that $R^+xy$ and
-$R^+yx$ but $x \neq y$. Since $\tuple{x,y} \in R \cup \Id{X}$, but
-$\tuple{x, y} \notin \Id{X}$, we must have $\tuple{x, y} \in R$, i.e.,
+To show $R^+$ is anti-symmetric, suppose for reductio that $R^+xy$ and
+$R^+yx$ but $x \neq y$. Since $\tuple{x,y} \in R \cup \Id{A}$, but
+$\tuple{x, y} \notin \Id{A}$, we must have $\tuple{x, y} \in R$, i.e.,
 $Rxy$. Similarly,~$Ryx$. But this contradicts the assumption
 that $R$ is asymmetric.
 
 To establish transitivity, suppose that $R^+xy$ and $R^+yz$. If both
 $\tuple{x, y} \in R$ and $\tuple{y,z} \in R$, then $\tuple{x, z} \in
 R$ since $R$~is transitive. Otherwise, either $\tuple{x, y} \in
-\Id{X}$, i.e., $x = y$, or $\tuple{y, z} \in \Id{X}$, i.e., $y = z$.
+\Id{A}$, i.e., $x = y$, or $\tuple{y, z} \in \Id{A}$, i.e., $y = z$.
 In the first case, we have that $R^+yz$ by assumption, $x = y$, hence
 $R^+xz$. Similarly in the second case. In either case, $R^+xz$, thus,
 $R^+$ is also transitive.
 
-Concerning the ``moreover'' clause, suppose $R$ is a total order,
-i.e., that $R$ is connected. So for all $x \neq y$, either $Rxy$
-or~$Ryx$, i.e., either $\tuple{x, y} \in R$ or $\tuple{y, x} \in R$.
-Since $R \subseteq R^+$, this remains true of $R^+$, so $R^+$ is
-connected as well.
+Concerning the ``moreover'' clause, suppose that $R$ is also connected. 
+So for all $x \neq y$, either $Rxy$ or~$Ryx$, i.e., either 
+$\tuple{x, y} \in R$ or $\tuple{y, x} \in R$. Since $R \subseteq R^+$, 
+this remains true of $R^+$, so $R^+$ is connected as well.
 \end{proof}
 
 \begin{prop}\ollabel{prop:partialtostrict}
-If $R$ is a partial order on~$X$, then $R^- = R \setminus \Id{X}$ is a
-strict order. Moreover, if $R$ is linear, then $R^-$ is total.
+If $R$ is a partial order on~$A$, then $R^- = R \setminus \Id{A}$ is a
+strict order. Moreover, if $R$ is a linear order, then $R^-$ is a strict 
+linear order.
 \end{prop}
 
 \begin{proof}
@@ -143,19 +138,13 @@ This is left as an exercise.
 Give a proof of \olref[sfr][rel][ord]{prop:partialtostrict}. 
 \end{prob}
 
-\begin{ex}
-$\le$ is the linear order corresponding to the total 
-order~$<$. $\subseteq$ is the partial order corresponding to
-the strict order~$\subsetneq$.
-\end{ex}
-
-The following simple result which establishes that total orders
+The following simple result establishes that strict linear orders
 satisfy an extensionality-like property:
 
-\begin{prop}\ollabel{prop:extensionality-totalorders}
-If $<$ totally orders $A$, then: 
+\begin{prop}\ollabel{prop:extensionality-strictlinearorders}
+If $<$ is a strict linear order on $A$, then:
 \[
-  (\forall a, b \in A)((\forall x \in A)(x < a \liff x < b) \lif a = b)
+  (\forall a, b \in A)((\forall x \in A)(x < a \liff x < b) \lif a = b).
 \]
 \end{prop}
 


### PR DESCRIPTION
Issue #334: definition 2.16, definition 2.24, and the footnote of section 5.6 provided conflicting definitions for "total order". To address this issue, since definition 2.16 provides what appears to be the intended version of "total order," and the type of order being defined in definition 2.24 (a strict order which is also connected) was already defined under definition 2.22 as a "strict linear order", the following changes were made (including some minor typo fixes and cosmetic changes for section consistency):

Definition 2.24: Removed. The first part of this definition conflicted with definition 2.16, and the second part of this definition was already defined under definition 2.22.

Definition 2.16: Added the label \ollabel{def:linearorder} to this definition and replaced all references to the label \ollabel{def:strictlinearorder}, from definition 2.24, with this label.

Definition 2.22: Added "strict total order" as an appropriate alternative name for "strict linear order" to mirror the approach taken in definition 2.16. However, throughout this section this type of order is still only referred to as a "strict linear order" rather than a "strict total order". This approach was taken to be consistent with the usage of definition 2.16 within the section ("linear order" is preferred over the alternative "total order"). Moved \ollabel{def:strictlinearorder} from the now removed definition 2.24 to this definition.

Proposition 2.25: Modified to refer to "strict linear order" rather than "total" based on the definition fixes. Several typos with "Id_X" were changed to "Id_A". Replaced occurrences of "antisymmetric" with "anti-symmetric" for consistency with the hyphenated spelling of the anti-symmetry definition given in definition 2.6 (but it should be noted that "antisymmetry" also appears elsewhere in the complete text and may be the preferred spelling).

Proposition 2.26: Modified to refer to "strict linear order" rather than "total" based on the definition fixes. The set "X" was changed to "A" for consistency with the rest of the section.

Example 2.27: Removed. This example was incompatible with definition 2.16. Additionally, a similar example, which is consistent with definition 2.16, is already given in example 2.23.

Proposition 2.28: Modified to clarify the use of "total" based on the definition fixes. Label \ollabel{prop:extensionality-totalorders} was changed to \ollabel{prop:extensionality-strictlinearorders} to be consistent with the definition fixes. Added a period to end the proposition sentence. Changed the sentence directly prior to this proposition to properly refer to "strict linear orders" rather than "total orders".

Section 5.6 footnote: This footnote was changed to refer to \ollabel{def:linearorder} (definition 2.16) instead of \ollabel{def:strictlinearorder}. The recalled definition of total order given in this footnote was also missing the anti-symmetric requirement for total orders, as defined in definition 2.16. This requirement is now added. Changed "total ordering" to "total order", for clarity, since the former had not been explicitly defined.