### PR TITLE
Replace hyphens with n-dashes when joining two names.

### DIFF
--- a/content/computability/recursive-functions/non-pr-functions.tex
+++ b/content/computability/recursive-functions/non-pr-functions.tex
@@ -82,12 +82,12 @@ function. If it is, compute the value of that function on input~$y$.
 \begin{digress}
 You may already be convinced that (with some work!) one can write a
 program (say, in Java or C++) that does this; and now we can appeal to
-the Church-Turing thesis, which says that anything that, intuitively,
+the Church--Turing thesis, which says that anything that, intuitively,
 is computable can be computed by a Turing machine.
 
 Of course, a more direct way to show that $g(x,y)$ is computable is to
 describe a Turing machine that computes it, explicitly. This would,
-in particular, avoid the Church-Turing thesis and appeals to
+in particular, avoid the Church--Turing thesis and appeals to
 intuition. Soon we will have built up enough machinery to show
 that $g(x,y)$ is computable, appealing to a model of computation that
 can be \emph{simulated} on a Turing machine: namely, the recursive

--- a/content/counterfactuals/introduction/counterfactuals.tex
+++ b/content/counterfactuals/introduction/counterfactuals.tex
@@ -71,7 +71,7 @@ an ``ontic'' analysis, since it makes reference to an ontology of
 possible worlds. Other analyses make use of conditional probabilities
 or theories of belief revision.  There is a proliferation of different
 proposed logics of counterfactuals. There isn't even a single
-Lewis-Stalnaker logic of counterfactuals: even though Stalnaker and
+Lewis--Stalnaker logic of counterfactuals: even though Stalnaker and
 Lewis proposed accounts along similar lines with reference to closest
 possible worlds, the assumptions they made result in different valid
 inferences.

--- a/content/counterfactuals/minimal-change-semantics/antecedent-strengthening.tex
+++ b/content/counterfactuals/minimal-change-semantics/antecedent-strengthening.tex
@@ -24,7 +24,7 @@ inference is invalid:
   Therefore, if the match were struck in outer space, it would light.
 \end{quote}
 
-The Lewis-Stalnaker account of conditionals explains this: the closest
+The Lewis--Stalnaker account of conditionals explains this: the closest
 world where I light the match and I do so in outer space is much
 further removed from the actual world than the closest world where I
 light the match is. So although it's true that the match lights in the

--- a/content/counterfactuals/minimal-change-semantics/transitivity.tex
+++ b/content/counterfactuals/minimal-change-semantics/transitivity.tex
@@ -29,7 +29,7 @@ true. Likewise, the second premise, considered in isolation is
 true. The conclusion, however, is false: in all likelihood, Hoover
 would have been a fervent Communist if he had been born in the USSR,
 and not been a traitor (to his country).  The intuitive assignment of
-truth values is borne out by the Stalnaker-Lewis account. The closest
+truth values is borne out by the Stalnaker--Lewis account. The closest
 possible world to ours with the only change being Hoover's place of
 birth is the one where Hoover grows up to be a good citizen of the
 USSR. This is the closest possible world where the antecedent of the

--- a/content/first-order-logic/beyond/intuitionistic-logic.tex
+++ b/content/first-order-logic/beyond/intuitionistic-logic.tex
@@ -106,7 +106,7 @@ consists of a procedure which returns a proof of $!A(x)$ for any value
 of~$x$; and a proof of $\lexists[x][!A(x)]$ consists of a value
 of~$x$, together with a proof that this value satisfies~$!A$. One can
 describe the interpretation in computational terms known as the
-``Curry-Howard isomorphism'' or the ``!!{formula}s-as-types
+``Curry--Howard isomorphism'' or the ``!!{formula}s-as-types
 paradigm'': think of !!a{formula} as specifying a certain kind of
 data type, and proofs as computational objects of these data types
 that enable us to see that the corresponding !!{formula} is true.

--- a/content/first-order-logic/beyond/second-order-logic.tex
+++ b/content/first-order-logic/beyond/second-order-logic.tex
@@ -206,7 +206,7 @@ logic. That's the good news; now for the bad. We have already
 mentioned that there is no effective !!{derivation} system that is complete for
 the full second-order semantics. For better or for worse, many of the
 properties of first-order logic are absent, including compactness and
-the L\"owenheim-Skolem theorems.
+the L\"owenheim--Skolem theorems.
 
 On the other hand, if one is willing to give up the full second-order
 semantics in terms of the weaker one, then the minimal second-order

--- a/content/first-order-logic/completeness/downward-ls.tex
+++ b/content/first-order-logic/completeness/downward-ls.tex
@@ -7,9 +7,9 @@
 \begin{document}
 
 \olfileid{fol}{com}{dls}
-\olsection{The L\"owenheim-Skolem Theorem}
+\olsection{The L\"owenheim--Skolem Theorem}
 
-The L\"owenheim-Skolem Theorem says that if a theory has an infinite
+The L\"owenheim--Skolem Theorem says that if a theory has an infinite
 model, then it also has a model that is at most !!{denumerable}. An
 immediate consequence of this fact is that first-order logic cannot
 express that the size of !!a{structure} is !!{nonenumerable}: any
@@ -46,7 +46,7 @@ of terms of the language~$\Lang L'$. So $\Struct{M}$ is
 \end{proof}
 
 \begin{ex}[Skolem's Paradox]
-Zermelo-Fraenkel set theory~$\Log{ZFC}$ is a very powerful framework
+Zermelo--Fraenkel set theory~$\Log{ZFC}$ is a very powerful framework
 in which practically all mathematical statements can be expressed,
 including facts about the sizes of sets. So for instance, $\Log{ZFC}$
 can prove that the set~$\Real$ of real numbers is !!{nonenumerable},
@@ -55,7 +55,7 @@ than the set itself, etc.  If $\Log{ZFC}$ is consistent, its models
 are all infinite, and moreover, they all contain !!{element}s about
 which the theory says that they are !!{nonenumerable}, such as the
 element that makes true the theorem of~$\Log{ZFC}$ that the power set
-of the natural numbers exists. By the L\"owenheim-Skolem Theorem,
+of the natural numbers exists. By the L\"owenheim--Skolem Theorem,
 $\Log{ZFC}$ also has !!{enumerable} models---models that contain
 ``!!{nonenumerable}'' sets but which themselves are !!{enumerable}.
 \end{ex}

--- a/content/first-order-logic/completeness/introduction.tex
+++ b/content/first-order-logic/completeness/introduction.tex
@@ -68,7 +68,7 @@ satisfiable'' sets of !!{sentence}s instead of consistent ones.
 \iftag{FOL}{The construction also yields other consequences, e.g.,
   that any satisfiable set of !!{sentence}s has a finite or
   !!{denumerable}s model.  (This result is called the
-  L\"owenheim-Skolem theorem.)  In general, the construction of
+  L\"owenheim--Skolem theorem.)  In general, the construction of
   !!{structure}s from sets of !!{sentence}s is used often in logic,
   and sometimes even in philosophy.}{}
 

--- a/content/first-order-logic/introduction/models-theories.tex
+++ b/content/first-order-logic/introduction/models-theories.tex
@@ -64,7 +64,7 @@ any~$n \in \PosInt$.  One can also express, using a set of infinitely
 many !!{sentence}s, that the !!{domain} is infinite.  But one cannot
 express that the domain is finite, or that the domain is
 !!{nonenumerable}. These results about the limitations of first-order
-languages are consequences of the compactness and L\"owenheim-Skolem
+languages are consequences of the compactness and L\"owenheim--Skolem
 theorems.
 
 \end{document}

--- a/content/first-order-logic/introduction/soundness-completeness.tex
+++ b/content/first-order-logic/introduction/soundness-completeness.tex
@@ -48,7 +48,7 @@ question: which sets of !!{sentence}s have models? Answer: all and only
 consistent sets do.
 
 The soundness and completeness theorems have two important
-consequences: the compactness and the L\"owenheim-Skolem theorem.
+consequences: the compactness and the L\"owenheim--Skolem theorem.
 These are important results in the theory of models, and can be used
 to establish many interesting results. We've already mentioned two:
 first-order logic cannot express that the !!{domain} of !!a{structure}

--- a/content/first-order-logic/models-theories/set-theory.tex
+++ b/content/first-order-logic/models-theories/set-theory.tex
@@ -15,7 +15,7 @@ Developing mathematics in this theory involves a number of things.
 First, it requires a set of axioms for the relation~$\in$.  A number
 of different axiom systems have been developed, sometimes with
 conflicting properties of~$\in$.  The axiom system known as
-$\Log{ZFC}$, Zermelo-Fraenkel set theory with the axiom of choice
+$\Log{ZFC}$, Zermelo--Fraenkel set theory with the axiom of choice
 stands out: it is by far the most widely used and studied, because it
 turns out that its axioms suffice to prove almost all the things
 mathematicians expect to be able to prove.  But before that can be

--- a/content/first-order-logic/models-theories/size-of-structures.tex
+++ b/content/first-order-logic/models-theories/size-of-structures.tex
@@ -67,6 +67,6 @@ not every infinite !!{structure} is a model of them).  The property of
 being a finite structure, and the property of being a
 !!{nonenumerable} structure cannot even be expressed with an infinite
 set of !!{sentence}s.  These facts follow from the compactness and
-L\"owenheim-Skolem theorems.
+L\"owenheim--Skolem theorems.
 
 \end{document}

--- a/content/history/biographies/alonzo-church.tex
+++ b/content/history/biographies/alonzo-church.tex
@@ -29,7 +29,7 @@ Stephen Kleene and Barkley Rosser, he developed a theory of effective
 calculability, the lambda calculus, independently of Alan Turing's
 development of the Turing machine. The two definitions of
 computability are equivalent, and give rise to what is now known as
-the \emph{Church-Turing Thesis}, that a function of the natural
+the \emph{Church--Turing Thesis}, that a function of the natural
 numbers is effectively computable if and only if it is computable via
 Turing machine (or lambda calculus). He also proved what is now known
 as \emph{Church's Theorem}: The decision problem for the validity of

--- a/content/incompleteness/incompleteness-provability/second-incompleteness-thm.tex
+++ b/content/incompleteness/incompleteness-provability/second-incompleteness-thm.tex
@@ -122,7 +122,7 @@ may consider ``finitary'' may lie outside the kinds of mathematics
 Hilbert wanted to formalize. But G\"odel was being charitable; today,
 it is hard to see how we might find something that can reasonably be
 called finitary but is not formalizable in, say, $\Th{ZFC}$,
-Zermelo-Fraenkel set theory with the axiom of choice.
+Zermelo--Fraenkel set theory with the axiom of choice.
 \end{digress}
 
 \end{document}

--- a/content/incompleteness/introduction/historical-background.tex
+++ b/content/incompleteness/introduction/historical-background.tex
@@ -164,7 +164,7 @@ set theory, which was expanded on by Fraenkel, Skolem, von Neumann,
 and others.  By the mid-1920s, there were two approaches that laid
 claim to the title of an axiomatization of ``all'' of mathematics, the
 \emph{Principia mathematica} of Russell and Whitehead, and what came to
-be known as Zermelo-Fraenkel set theory.
+be known as Zermelo--Fraenkel set theory.
 
 In 1921, Hilbert set out on a research project to establish the goal
 of proving these systems to be consistent.  He was aided in this

--- a/content/incompleteness/representability-in-q/comp-representable.tex
+++ b/content/incompleteness/representability-in-q/comp-representable.tex
@@ -14,7 +14,7 @@ Every computable function is representable in~$\Th{Q}$.
 \end{thm}
 
 \begin{proof}
-For definiteness, and using the Church-Turing Thesis, let's say that a
+For definiteness, and using the Church--Turing Thesis, let's say that a
 function is computable iff it is general recursive. The general
 recursive functions are those which can be defined from the zero
 function~$\Zero$, the successor function~$\Succ$, and the projection
@@ -47,7 +47,7 @@ computable functions. But, conversely, in any !!{derivation} system in
 which the notion of !!{derivation} is computable, every representable
 function is computable. So, for example, the set of computable
 functions can be characterized as the set of functions representable
-in Peano arithmetic, or even Zermelo-Fraenkel set theory. As G\"odel
+in Peano arithmetic, or even Zermelo--Fraenkel set theory. As G\"odel
 noted, this is somewhat surprising.  We will see that when it comes to
 provability, questions are very sensitive to which theory you
 consider; roughly, the stronger the axioms, the more you can prove.

--- a/content/incompleteness/theories-computability/interpretability.tex
+++ b/content/incompleteness/theories-computability/interpretability.tex
@@ -27,7 +27,7 @@ this definition precise.
 
 The proof is just a small modification of the proof of the last
 theorem; one could use a counterexample to get a separation of $\Th{Q}$ and
-$\Th{\bar Q}$. One can take $\Th{ZFC}$, Zermelo-Fraenkel set theory with the
+$\Th{\bar Q}$. One can take $\Th{ZFC}$, Zermelo--Fraenkel set theory with the
 axiom of choice, to be an axiomatic foundation that is powerful enough
 to carry out a good deal of ordinary mathematics. In $\Th{ZFC}$ one
 can define the natural numbers, and via this interpretation, the

--- a/content/intuitionistic-logic/introduction/bhk-interpretation.tex
+++ b/content/intuitionistic-logic/introduction/bhk-interpretation.tex
@@ -8,7 +8,7 @@
 
 \olfileid{int}{int}{bhk}
 
-\olsection{The Brouwer-Heyting-Kolmogorov Interpretation}
+\olsection{The Brouwer--Heyting--Kolmogorov Interpretation}
 
 \begin{editorial}
   Proofs of validity of intuitionistic propositions using the BHK
@@ -16,7 +16,7 @@
 \end{editorial}
 
 There is an informal constructive interpretation of the intuitionist
-connectives, usually known as the Brouwer-Heyting-Kolmogorov
+connectives, usually known as the Brouwer--Heyting--Kolmogorov
 interpretation. It uses the notion of a ``construction,'' which you
 may think of as a constructive proof. (We don't use ``proof'' in the
 BHK interpretation so as not to get confused with the notion of

--- a/content/intuitionistic-logic/propositions-as-types/introduction.tex
+++ b/content/intuitionistic-logic/propositions-as-types/introduction.tex
@@ -81,7 +81,7 @@ Similar correspondences hold between the rules for $\land$ and ``product''
 types, and between the rules for $\lor$ and ``sum'' types.
 
 This correspondence between terms in the simply typed lambda calculus
-and natural deduction !!{derivation}s is called the ``Curry-Howard'',
+and natural deduction !!{derivation}s is called the ``Curry--Howard'',
 or ``propositions as types'' correspondence.  In addition to
 !!{formula}s (propositions) corresponding to types, and proofs to
 terms, we can summarize the correspondences as follows:
@@ -102,7 +102,7 @@ terms, we can summarize the correspondences as follows:
   \end{tabular}
 \end{center}
 
-The Curry-Howard correspondence is one of the cornerstones of
+The Curry--Howard correspondence is one of the cornerstones of
 automated proof assistants and type checkers for programs, since
 checking a proof witnessing a proposition (as we did above) amounts to
 checking if a program (term) has the declared type.

--- a/content/intuitionistic-logic/propositions-as-types/propositions-as-types.tex
+++ b/content/intuitionistic-logic/propositions-as-types/propositions-as-types.tex
@@ -9,7 +9,7 @@
 
 \begin{editorial}
   This is a \emph{very experimental} draft of a chapter on the
-  Curry-Howard correspondence.  It needs more explanation and
+  Curry--Howard correspondence.  It needs more explanation and
   motivation, and there are probably errors and omissions. The proof
   of normalization should be reviewed and expanded. There are no
   examples for the product type. Permutation and simplification

--- a/content/lambda-calculus/church-rosser/beta-eta-reduction.tex
+++ b/content/lambda-calculus/church-rosser/beta-eta-reduction.tex
@@ -10,7 +10,7 @@
 
 \olsection{$\beta\eta$-reduction}
 
-The Church-Rosser property holds for
+The Church--Rosser property holds for
 $\beta\eta$-reduction ($\bered$).
 
 \begin{lem}\ollabel{lem:one-par}
@@ -49,7 +49,7 @@ $\beta\eta$-reduction ($\bered$).
 \end{proof}
 
 \begin{thm}\ollabel{thm:cr}
-  $\bered$ satisfies Church-Rosser property.
+  $\bered$ satisfies Church--Rosser property.
 \end{thm}
 
 \begin{proof}

--- a/content/lambda-calculus/church-rosser/beta-reduction.tex
+++ b/content/lambda-calculus/church-rosser/beta-reduction.tex
@@ -68,7 +68,7 @@
 \end{proof}
 
 \begin{thm}\ollabel{thm:cr}
-  $\bred$ satisfies the Church-Rosser property.
+  $\bred$ satisfies the Church--Rosser property.
 \end{thm}
 
 \begin{proof}

--- a/content/lambda-calculus/church-rosser/church-rosser.tex
+++ b/content/lambda-calculus/church-rosser/church-rosser.tex
@@ -5,7 +5,7 @@
 
 \begin{document}
 
-\olchapter{lam}{cr}{The Church-Rosser Property}
+\olchapter{lam}{cr}{The Church--Rosser Property}
 
 \olimport{definitions-and-properties}
 \olimport{parallel-beta-reduction}

--- a/content/lambda-calculus/church-rosser/definitions-and-properties.tex
+++ b/content/lambda-calculus/church-rosser/definitions-and-properties.tex
@@ -10,18 +10,18 @@
 
 \olsection{Definition and Properties}
 
-In this chapter we introduce the concept of Church-Rosser property and
+In this chapter we introduce the concept of Church--Rosser property and
 some common properties of this property.
 
-\begin{defn}[Church-Rosser property, CR] A relation $\xredone$ on
-  terms is said to satisfy the \emph{Church-Rosser property} iff,
+\begin{defn}[Church--Rosser property, CR] A relation $\xredone$ on
+  terms is said to satisfy the \emph{Church--Rosser property} iff,
   whenever $M \xredone P$ and $M \xredone Q$, then there exists
   some~$N$ such that $P \xredone N$ and $Q \xredone N$.
 \end{defn}
 
 We can view the lambda calculus as a model of computation in which
 terms in normal form are ``values'' and a reducibility relation on
-terms are the ``calculation rules.'' The Church-Rosser property states
+terms are the ``calculation rules.'' The Church--Rosser property states
 is that when there is more than one way to proceed with a calculation,
 there is still only a single value of the expression.
 
@@ -33,9 +33,9 @@ distributivity). Both of these, however, can be further reduced to
 $12+3$.
 
 If we take $\xredone$ to be $\beta$-reduction, we easily see that a
-consequence of the Church-Rosser property is that if a term has a
+consequence of the Church--Rosser property is that if a term has a
 normal form, then it is unique. For suppose $M$ can be reduced to $P$
-and $Q$, both of which are normal forms. By Church-Rosser property,
+and $Q$, both of which are normal forms. By the Church--Rosser property,
 there exists some $N$ such that both $P$ and $Q$ reduce to it. Since
 by assumption $P$ and $Q$ are normal forms, the reduction of $P$ and
 $Q$ to $N$ can only be the trivial reduction, i.e., $P$, $Q$, and $N$
@@ -49,9 +49,9 @@ only one, if any, final result of a computation, just like there is
 only one result of computing $4 \times (1+2)+3$, namely~$15$.
 
 \begin{thm} \ollabel{thm:str}
-  If a relation $\xredone$ satisfies the Church-Rosser property, and $\xred$ is the
+  If a relation $\xredone$ satisfies the Church--Rosser property, and $\xred$ is the
   smallest transitive relation containing $\xredone$, then $\xred$ satisfies
-  the Church-Rosser property too.
+  the Church--Rosser property too.
 \end{thm}
 
 \begin{proof}
@@ -74,7 +74,7 @@ only one result of computing $4 \times (1+2)+3$, namely~$15$.
     N_{i,j} &= R
   \end{align*}
   where $R$ is a term such that $N_{i-1,j} \xredone R$ and $N_{i,j-1}
-  \xredone R$. By the Church-Rosser property of $\xredone$, such a
+  \xredone R$. By the Church--Rosser property of $\xredone$, such a
   term always exists.
 
   Now we have $N_{m,0} \xredone \dots \xredone N_{m,n}$ and $N_{0,n}

--- a/content/lambda-calculus/church-rosser/parallel-beta-reduction.tex
+++ b/content/lambda-calculus/church-rosser/parallel-beta-reduction.tex
@@ -11,7 +11,7 @@
 \olsection{Parallel $\beta$-reduction}
 
 We introduce the notion of \emph{parallel $\beta$-reduction}, and
-prove the it has the Church-Rosser property.
+prove the it has the Church--Rosser property.
 
 \begin{defn}[parallel $\beta$-reduction, $\bredpar$] \ollabel{defn:bredpar}
   Parallel reduction ($\bredpar$) of terms is inductively defined as follows:
@@ -145,7 +145,7 @@ of $(\lambd[f][fx])(\lambd[y][y])$ is $(\lambd[y][y])x$, not itself.
 \end{prob}
 
 \begin{thm}\ollabel{thm:cr}
-  $\bredpar$ has the Church-Rosser property.
+  $\bredpar$ has the Church--Rosser property.
 \end{thm}
 
 \begin{proof}

--- a/content/lambda-calculus/introduction/church-rosser.tex
+++ b/content/lambda-calculus/introduction/church-rosser.tex
@@ -7,7 +7,7 @@
 \begin{document}
 
 \olfileid{lam}{int}{cr}
-\olsection{The Church-Rosser Property}
+\olsection{The Church--Rosser Property}
 
 \begin{thm}
 \ollabel{thm:church-rosser}

--- a/content/lambda-calculus/introduction/reduction.tex
+++ b/content/lambda-calculus/introduction/reduction.tex
@@ -70,6 +70,6 @@ both terms further reduce to the same term, $zv$.
 
 The final outcome in the last example is not a coincidence, but rather
 illustrates a deep and important property of the lambda calculus, known as the
-``Church-Rosser property.''
+``Church--Rosser property.''
 
 \end{document}

--- a/content/lambda-calculus/lambda-calculus.tex
+++ b/content/lambda-calculus/lambda-calculus.tex
@@ -9,7 +9,7 @@
 \begin{editorial}
 This part deals with the lambda calculus. The introduction chapter is
 based on Jeremy Avigad's notes; part of it is now redundant and covered in
-later chapters. The chapters on syntax, Church-Rosser property, and
+later chapters. The chapters on syntax, Church--Rosser property, and
 lambda definability were produced by Zesen Qian during his Mitacs summer
 internship. They still have to be reviewed and revised.
 \end{editorial}

--- a/content/lambda-calculus/syntax/beta.tex
+++ b/content/lambda-calculus/syntax/beta.tex
@@ -83,7 +83,7 @@ both terms further reduce to the same term, $zv$.
 
 The final outcome in the last example is not a coincidence, but rather
 illustrates a deep and important property of the lambda calculus, known as the
-Church-Rosser property.
+Church--Rosser property.
 
 \begin{digress}
   In general, there is more than one way to $\beta$-reduce a term,

--- a/content/many-valued-logic/infinite-valued-logics/goedel.tex
+++ b/content/many-valued-logic/infinite-valued-logics/goedel.tex
@@ -112,7 +112,7 @@ p)$, is also a tautology in~$\LogGod[\infty]$. In fact,
 $\LogGod[\infty]$ can be characterized as intuitionistic logic to
 which the schema $(!A \lif !B) \lor (!B \lif !A)$ is added. This was
 shown by Michael Dummett, and so $\LogGod[\infty]$ is often referred to
-as G\"odel-Dummett logic~$\Log{LC}$.
+as G\"odel--Dummett logic~$\Log{LC}$.
 
 \begin{prob}
   Show that $(p \lif q) \lor (q \lif p)$ is a

--- a/content/methods/proofs/introduction.tex
+++ b/content/methods/proofs/introduction.tex
@@ -47,7 +47,7 @@ important enough to record, but perhaps not particularly deep nor
 applied often. A theorem is a significant, important proposition. Its
 proof often is broken into several steps, and sometimes it is named
 after the person who first proved it (e.g., Cantor's Theorem, the
-L\"owenheim-Skolem theorem) or after the fact it concerns (e.g., the
+L\"owenheim--Skolem theorem) or after the fact it concerns (e.g., the
 completeness theorem).  A lemma is a proposition or theorem that is
 used in the proof of a more important result. Confusingly,
 sometimes lemmas are important results in themselves, and also named

--- a/content/model-theory/basics/isomorphism.tex
+++ b/content/model-theory/basics/isomorphism.tex
@@ -17,7 +17,7 @@ true---for instance, one can be !!{enumerable} and the other not.
 This is because there are lots of features of !!a{structure} that
 cannot be expressed in first-order languages, either because the
 language is not rich enough, or because of fundamental limitations of
-first-order logic such as the L\"owenheim-Skolem theorem. So another,
+first-order logic such as the L\"owenheim--Skolem theorem. So another,
 stricter, aspect in which !!{structure}s can be alike is if they are
 fundamentally the same, in the sense that they only differ in the
 objects that make them up, but not in their structural features. A way

--- a/content/model-theory/basics/nonstandard-arithmetic.tex
+++ b/content/model-theory/basics/nonstandard-arithmetic.tex
@@ -44,7 +44,7 @@ consider the theory
 \]
 The theory is finitely satisfiable, so by compactness it has a model
 $\Struct{M}$, which can be taken to be !!{enumerable} by the Downward
-L\"owenheim-Skolem theorem. Where $\Domain{M}$ is the domain of
+L\"owenheim--Skolem theorem. Where $\Domain{M}$ is the domain of
 $\Struct{M}$, let $\Struct{M}$ interpret the non-logical constants of
 $\Lang{L}$ as $\mathbf{z} = \Assign{\Obj{0}}{M} \in \Domain{M}$, ${\prec} =
 \Assign{<}{M} \subseteq M^2$, $* = \Assign{\prime}{M} \colon
@@ -67,7 +67,7 @@ irreflexive. So $\Struct{M}$ is non-standard.
 A relation $R$ over a set $X$ is \emph{well-founded} if and only if
 there are no infinite descending chains in~$R$, i.e., if there are no
 $x_0$, $x_1$, $x_2$,~\dots in $X$ such that $\dots x_2Rx_1Rx_0$.  Assuming
-Zermelo-Fraenkel set theory~$ZF$ is consistent, show that there are
+Zermelo--Fraenkel set theory~$ZF$ is consistent, show that there are
 non-well-founded models of $ZF$, i.e., models $\mathfrak{M}$ such that
 $\dots x_2 \in x_1 \in x_0$.
 \end{prob}

--- a/content/model-theory/basics/theory-of-m.tex
+++ b/content/model-theory/basics/theory-of-m.tex
@@ -54,7 +54,7 @@ $\Struct{M} \elemequiv \Struct{N}$.
   comprising only a 2-place !!{predicate} interpreted as the $<$
   relation over the reals. Clearly $\Struct{R}$ is !!{nonenumerable};
   however, since $\Theory{R}$ is obviously consistent, by the
-  L\"owenheim-Skolem theorem it has !!a{enumerable} model, say
+  L\"owenheim--Skolem theorem it has !!a{enumerable} model, say
   $\Struct{S}$, and by \olref{prop:equiv}, $\Struct{R}
   \equiv \Struct{S}$. Moreover, since $\Struct{R}$ and $\Struct{S}$
   are not isomorphic, this shows that the converse of

--- a/content/model-theory/lindstrom/introduction.tex
+++ b/content/model-theory/lindstrom/introduction.tex
@@ -12,7 +12,7 @@
 In this chapter we aim to prove Lindstr\"om's characterization of
 first-order logic as the maximal logic for which (given certain
 further constraints) the Compactness and the Downward
-L\"owenheim-Skolem theorems hold
+L\"owenheim--Skolem theorems hold
 (\olref[fol][com][com]{thm:compactness} and
 \olref[fol][com][dls]{thm:downward-ls}). First, we need a more general
 characterization of the general class of logics to which the theorem

--- a/content/model-theory/lindstrom/lindstrom-proof.tex
+++ b/content/model-theory/lindstrom/lindstrom-proof.tex
@@ -46,7 +46,7 @@ $!D_\Struct{N}$ is a disjunct in $!D$, and since $\Struct{N}
 
 \begin{thm}[Lindstr\"om's Theorem]
   \ollabel{thm:lindstrom} Suppose $\tuple{L, \models_L}$ has the
-  Compactness and the L\"owenheim-Skolem Properties. Then
+  Compactness and the L\"owenheim--Skolem Properties. Then
   $\tuple{L, \models_L} \le \tuple{F, \models}$ (so
   $\tuple{L, \models_L}$ is equivalent to first-order logic).
 \end{thm}

--- a/content/model-theory/lindstrom/ls-property.tex
+++ b/content/model-theory/lindstrom/ls-property.tex
@@ -8,10 +8,10 @@
 
 \olfileid{mod}{lin}{lsp}
 
-\olsection{Compactness and L\"owenheim-Skolem Properties}
+\olsection{Compactness and L\"owenheim--Skolem Properties}
 
 We now give the obvious extensions of compactness and
-L\"owenheim-Skolem to the case of abstract logics. 
+L\"owenheim--Skolem to the case of abstract logics.
 
 \begin{defn}
 An abstract logic $\tuple{L, \models_L}$ has the \emph{Compactness
@@ -21,7 +21,7 @@ satisfiable.
 \end{defn}
 
 \begin{defn}
-$\tuple{L, \models_L}$ has the \emph{Downward L\"owenheim-Skolem
+$\tuple{L, \models_L}$ has the \emph{Downward L\"owenheim--Skolem
   property} if any satisfiable $\Gamma$ has !!a{enumerable} model.
 \end{defn}
 
@@ -36,12 +36,12 @@ logics. In case of first-order logic, we know from
 isomorphic then they are elementarily equivalent. That proof does not
 carry over to abstract logics, for induction on !!{formula}s need not
 be available for arbitrary $!E \in L(\Lang{L})$, but the theorem is
-true nonetheless, provided the L\"owenheim-Skolem property holds.
+true nonetheless, provided the L\"owenheim--Skolem property holds.
 
 \begin{thm}
 \ollabel{thm:abstract-p-isom}
 Suppose $\tuple{L, \models_L}$ is a normal logic with the
-L\"owenheim-Skolem property. Then any two !!{structure}s that are
+L\"owenheim--Skolem property. Then any two !!{structure}s that are
 partially isomorphic are elementarily equivalent in $\tuple{L,
   \models_L}$.
 \end{thm}
@@ -112,7 +112,7 @@ true in $\Struct{M}$ saying that $\Struct{M} \models_L !E$ and
 $\Struct{N} \not\models_L !E$ (this requires the Relativization
 Property), as well as a \emph{first-order} !!{sentence} $!D_2$ true in
 $\Struct{M}$ saying that $\Struct{M} \simeq_p \Struct{N}$ via the
-partial isomorphism~$I$. By the L\"owenheim-Skolem Property, $!D_1$
+partial isomorphism~$I$. By the L\"owenheim--Skolem Property, $!D_1$
 and $!D_2$ are jointly true in !!a{enumerable} model $\Struct{M}_0$
 containing partially isomorphic substructures $\Struct{M}_0$ and
 $\Struct{N}_0$ such that $\Struct{M}_0 \models_L !E$ and $\Struct{N}_0

--- a/content/second-order-logic/metatheory/introduction.tex
+++ b/content/second-order-logic/metatheory/introduction.tex
@@ -31,7 +31,7 @@ systems are available and in fact are important objects of research).
 
 First-order logic also has two more properties: it is compact (if
 every finite subset of a set~$\Gamma$ of !!{sentence}s is satisfiable,
-$\Gamma$ itself is satisfiable) and the L\"owenheim-Skolem Theorem
+$\Gamma$ itself is satisfiable) and the L\"owenheim--Skolem Theorem
 holds for it (if $\Gamma$ has an infinite model it has
 !!a{denumerable} model). Both of these results fail for second-order
 logic. Again, the reason is that second-order logic can express facts

--- a/content/second-order-logic/metatheory/loewenheim-skolem.tex
+++ b/content/second-order-logic/metatheory/loewenheim-skolem.tex
@@ -8,22 +8,22 @@
 
 \olfileid{sol}{met}{lst}
 
-\olsection{The L\"owenheim-Skolem Theorem Fails for Second-order Logic}
+\olsection{The L\"owenheim--Skolem Theorem Fails for Second-order Logic}
 
 \begin{explain}
-The (Downward) L\"owenheim-Skolem Theorem states that every set of
+The (Downward) L\"owenheim--Skolem Theorem states that every set of
 !!{sentence}s with an infinite model has !!a{enumerable} model.  It,
 too, is a consequence of the completeness theorem: the proof of
 completeness generates a model for any consistent set of
 !!{sentence}s, and that model is !!{enumerable}.  There is also an
-Upward L\"owenheim-Skolem Theorem, which guarantees that if a set of
+Upward L\"owenheim--Skolem Theorem, which guarantees that if a set of
 !!{sentence}s has !!a{denumerable} model it also has
 !!a{nonenumerable} model.  Both theorems fail in second-order logic.
 \end{explain}
 
 
 \begin{thm}
-\ollabel{thm:sol-no-ls} The L\"owenheim-Skolem Theorem fails for
+\ollabel{thm:sol-no-ls} The L\"owenheim--Skolem Theorem fails for
 second-order logic: There are !!{sentence}s with infinite models but
 no !!{enumerable} models.
 \end{thm}

--- a/content/set-theory/cardinals/milestone.tex
+++ b/content/set-theory/cardinals/milestone.tex
@@ -16,7 +16,7 @@ the Separation and Replacement schemes. Otherwise put, $\ZFC$ adds
 Well-Ordering to~$\ZF$. 
 \end{defn}
 
-$\ZFC$ stands for \emph{Zermelo-Fraenkel} set theory with
+$\ZFC$ stands for \emph{Zermelo--Fraenkel} set theory with
 \emph{Choice}. Now this might seem slightly odd, since the axiom we
 added was called ``Well-Ordering'', not ``Choice''. But, when we later
 formulate {Choice}, it will turn out that Well-Ordering is equivalent

--- a/content/set-theory/choice/banach.tex
+++ b/content/set-theory/choice/banach.tex
@@ -3,7 +3,7 @@
 \begin{document}
 
 \olfileid{sth}{choice}{banach}
-\olsection{The Banach-Tarski Paradox}
+\olsection{The Banach--Tarski Paradox}
 
 We might also attempt to justify Choice, as Boolos attempted to
 justify Replacement, by appealing to \emph{extrinsic} considerations
@@ -16,7 +16,7 @@ Sometimes, however, it is claimed that Choice has \emph{undesirable}
 consequences. Mostly, this is due to a result by
 \cite{BanachTarski1924}. 
 
-\begin{thm}[Banach-Tarski Paradox (in $\ZFC$)]
+\begin{thm}[Banach--Tarski Paradox (in $\ZFC$)]
 Any ball can be decomposed into finitely many pieces, which can be
 reassembled (by rotation and transportation) to form two copies of
 that ball.
@@ -25,7 +25,7 @@ that ball.
 At first glance, this is a bit amazing. Clearly the two balls have
 \emph{twice} the volume of the original ball. But rigid
 motions---rotation and transportation---do not change volume. So it
-looks as if Banach-Tarski allows us to magick new matter into
+looks as if Banach--Tarski allows us to magick new matter into
 existence.
 
 It gets worse.\footnote{See \citet[Theorem 3.12]{Wagon2016}.} Similar
@@ -34,7 +34,7 @@ can then be reassembled (by rotation and transportation) to form an
 entity the shape and size of Big Ben.
 
 None of this, however, holds in $\ZF$ on its own.\footnote{Though
-Banach-Tarski can be proved with principles which are strictly weaker
+Banach--Tarski can be proved with principles which are strictly weaker
 than Choice; see \citet[303]{Wagon2016}.} So we face a decision:
 reject Choice, or learn to live with the ``paradox''. 
 
@@ -54,7 +54,7 @@ similar points, using other examples.}
 \end{enumerate}
 None of these three results require Choice. Indeed, we now just regard
 them as surprising, lovely, bits of mathematics. Maybe we should adopt
-the same attitude to the Banach-Tarski Paradox.
+the same attitude to the Banach--Tarski Paradox.
 
 To be sure, a technical observation is required here; but it only
 requires keeping a level head. Rigid motions preserve volume.
@@ -72,11 +72,11 @@ you should form \emph{all possible} collections of earlier-available
 sets. 
 
 If none of that convinces, here is a final (extrinsic) argument in
-favour of embracing the Banach-Tarski Paradox. It immediately entails
+favour of embracing the Banach--Tarski Paradox. It immediately entails
 the best math joke of all time:
 \begin{enumerate}
-	\item[] \emph{Question}. What's an anagram of ``Banach-Tarski''? 
-	\item[] \emph{Answer}. ``Banach-Tarski Banach-Tarski''.
+	\item[] \emph{Question}. What's an anagram of ``Banach--Tarski''? 
+	\item[] \emph{Answer}. ``Banach--Tarski Banach--Tarski''.
 \end{enumerate}
 
 \end{document}

--- a/content/set-theory/choice/tarskiscott.tex
+++ b/content/set-theory/choice/tarskiscott.tex
@@ -3,7 +3,7 @@
 \begin{document}
 
 \olfileid{sth}{choice}{tarskiscott}
-\olsection{The Tarski-Scott Trick}
+\olsection{The Tarski--Scott Trick}
 
 In \olref[cardinals][cardsasords]{defcardinalasordinal}, we
 defined cardinals as ordinals. To do this, we assumed the Axiom of
@@ -32,7 +32,7 @@ not exist, since it cannot have a rank.
 
 To get around this problem, we use a trick due to Tarski and Scott:\footnote{A reminder: all formulas may have parameters (unless explicitly stated otherwise).}
 
-\begin{defn}[Tarski-Scott]
+\begin{defn}[Tarski--Scott]
 For any formula $\phi(x)$, let
 $[ x : \phi(x)] $ be the set of all $x$, of least possible rank, such
 that $\phi(x)$ (or $\emptyset$, if there are no $\phi$s).
@@ -47,7 +47,7 @@ that  $(\exists x\subseteq V_\alpha)\phi(x)$, i.e., $(\forall \beta
 define $[x : \phi(x)]$ by Separation as $\Setabs{x \in
 V_{\alpha+1}}{\phi(x)}$. 
 
-Having justified the Tarski-Scott trick, we can now use it to define
+Having justified the Tarski--Scott trick, we can now use it to define
 a notion of cardinality:
 
 \begin{defn}
@@ -66,7 +66,7 @@ For example, if we restate
 without assuming Well-Ordering. 
 
 Whilst we are on the topic, it is worth noting that we can also
-develop a theory of ordinals using the Tarski-Scott trick. Where
+develop a theory of ordinals using the Tarski--Scott trick. Where
 $\tuple{A, <}$ is a well-ordering, let $\text{tso}(A, <) = [\tuple{X,
 R} : \ordeq{\tuple{A, <}}{\tuple{X, R}}]$. For more on this treatment
 of cardinals and ordinals, see \citet[chs.~9--12]{Potter2004}.

--- a/content/sets-functions-relations/sets/pairs-and-products.tex
+++ b/content/sets-functions-relations/sets/pairs-and-products.tex
@@ -22,7 +22,7 @@ share the same first element and share the same second element, i.e.:
 \[
   \tuple{a, b}= \tuple{c, d}\text{ iff both }a = c \text{ and }b=d.
 \]
-We can define ordered pairs in set theory using the Wiener-Kuratowski
+We can define ordered pairs in set theory using the Wiener--Kuratowski
 definition.
 \end{explain}
 

--- a/content/turing-machines/machines-computations/church-turing-thesis.tex
+++ b/content/turing-machines/machines-computations/church-turing-thesis.tex
@@ -7,7 +7,7 @@
 \begin{document}
 
 \olfileid{tur}{mac}{ctt}
-\olsection{The Church-Turing Thesis}
+\olsection{The Church--Turing Thesis}
 
 Turing machines are supposed to be a precise replacement for the
 concept of an effective procedure. Turing thought that anyone who
@@ -18,29 +18,29 @@ This claim is given support by the fact that all the other proposed
 precise replacements for the concept of an effective procedure turn
 out to be extensionally equivalent to the concept of a Turing machine
 ---that is, they can compute exactly the same set of functions. This
-claim is called the \emph{Church-Turing thesis}.
+claim is called the \emph{Church--Turing thesis}.
 
-\begin{defn}[Church-Turing thesis]
-The \emph{Church-Turing Thesis} states that anything computable via 
+\begin{defn}[Church--Turing thesis]
+The \emph{Church--Turing Thesis} states that anything computable via
 an effective procedure is Turing computable.
 \end{defn}
 
-The Church-Turing thesis is appealed to in two ways.  The first kind
-of use of the Church-Turing thesis is an excuse for laziness.  Suppose
+The Church--Turing thesis is appealed to in two ways.  The first kind
+of use of the Church--Turing thesis is an excuse for laziness.  Suppose
 we have a description of an effective procedure to compute something,
-say, in ``pseudo-code.''  Then we can invoke the Church-Turing thesis
+say, in ``pseudo-code.''  Then we can invoke the Church--Turing thesis
 to justify the claim that the same function is computed by some Turing
 machine, even if we have not in fact constructed it.
 
-The other use of the Church-Turing thesis is more philosophically
+The other use of the Church--Turing thesis is more philosophically
 interesting.  It can be shown that there are functions which cannot be
-computed by Turing machines.  From this, using the Church-Turing
+computed by Turing machines.  From this, using the Church--Turing
 thesis, one can conclude that it cannot be effectively computed, using
 any procedure whatsoever.  For if there were such a procedure, by the
-Church-Turing thesis, it would follow that there would be a Turing
+Church--Turing thesis, it would follow that there would be a Turing
 machine for it.  So if we can prove that there is no Turing machine
 that computes it, there also can't be an effective procedure.  In
-particular, the Church-Turing thesis is invoked to claim that the
+particular, the Church--Turing thesis is invoked to claim that the
 so-called halting problem not only cannot be solved by Turing
 machines, it cannot be effectively solved at all.
 

--- a/content/turing-machines/undecidability/decision-problem.tex
+++ b/content/turing-machines/undecidability/decision-problem.tex
@@ -19,7 +19,7 @@ the decision problem cannot be solved by a Turing machine.  That is,
 we show that there is no Turing machine which, whenever it is started
 on a tape that contains a first-order !!{sentence}, eventually halts
 and outputs either $1$ or~$0$ depending on whether the
-!!{sentence} is valid or not. By the Church-Turing thesis, every
+!!{sentence} is valid or not. By the Church--Turing thesis, every
 function which is computable is Turing computable. So if this
 ``validity function'' were effectively computable at all, it would be
 Turing computable. If it isn't Turing computable, then, it also cannot

--- a/content/turing-machines/undecidability/introduction.tex
+++ b/content/turing-machines/undecidability/introduction.tex
@@ -48,7 +48,7 @@ is essential to fix a specific model of computation, and show
 that there are functions it cannot compute or problems it cannot
 decide.  We can show, for instance, that not every function can be
 computed by Turing machines, and not every problem can be decided by
-Turing machines.  We can then appeal to the Church-Turing thesis to
+Turing machines.  We can then appeal to the Church--Turing thesis to
 conclude that not only are Turing machines not powerful enough to
 compute every function, but no effective procedure can.
 
@@ -92,6 +92,6 @@ Historically, the question of finding a procedure to effectively solve
 this problem was called simply ``the'' decision problem; and so we say
 that the decision problem is unsolvable.  Turing and Church proved this
 result independently at around the same time, so it is also called the
-Church-Turing Theorem.
+Church--Turing Theorem.
 
 \end{document}

--- a/content/turing-machines/undecidability/universal-tm.tex
+++ b/content/turing-machines/undecidability/universal-tm.tex
@@ -34,7 +34,7 @@ different descriptions will have different indices.
 Importantly, it is possible to give the enumeration of Turing machine
 descriptions in such a way that we can effectively compute the
 description of~$M$ from its index, and to effectively compute an index
-of a machine~$M$ from its description.  By the Church-Turing thesis,
+of a machine~$M$ from its description.  By the Church--Turing thesis,
 it is then possible to find a Turing machine which recovers the
 description of the Turing machine with index~$e$ and writes the
 corresponding description on its tape as output. The description would
@@ -70,7 +70,7 @@ A remarkable result is the following:
 \begin{proof}
   To actually produce~$U$ is basically impossible, since it is an
   extremely complicated machine. But we can describe in outline how it
-  works, and then invoke the Church-Turing thesis.  When it starts,
+  works, and then invoke the Church--Turing thesis.  When it starts,
   $U$'s tape contains a block of $e$ $\TMstroke$'s followed by a block
   of $n$~$\TMstroke$'s. It first ``decodes'' the index~$e$ to the
   right of the input~$n$. This produces a list of numbers (i.e.,


### PR DESCRIPTION
E.g. 'L\"owenheim-Skolem' becomes 'L\"owenheim--Skolem'.

This comports with general typesetting practice in which names of distinct persons, date ranges etc. are joined by n-dashes rather than hyphens.

So e.g. 'Burali-Forti' remains as is, joined by a hyphen, since it is a single (albeit double-barrelled) name.