### PR TITLE
Replace 'term' with 'closed term' at various points in the quotient model construction

### DIFF
--- a/content/first-order-logic/completeness/construction-of-model.tex
+++ b/content/first-order-logic/completeness/construction-of-model.tex
@@ -118,9 +118,9 @@ and so by induction this holds for every closed term~$t$.
 Let $\Struct M(\Gamma^*)$ be the term model of \olref{defn:termmodel}.
 \begin{tagenumerate}{prvEx,prvAll}
 \tagitem{prvEx}{$\Sat{M(\Gamma^*)}{\lexists[x][!A(x)]}$ iff
-  $\Sat{M(\Gamma^*)}{!A(t)}$ for at least one term~$t$.}{}
+  $\Sat{M(\Gamma^*)}{!A(t)}$ for at least one closed term~$t$.}{}
 \tagitem{prvAll}{$\Sat{M(\Gamma^*)}{\lforall[x][!A(x)]}$ iff
-  $\Sat{M(\Gamma^*)}{!A(t)}$ for all terms~$t$.}{}
+  $\Sat{M(\Gamma^*)}{!A(t)}$ for all closed terms~$t$.}{}
 \end{tagenumerate}
 \end{prop}
 

--- a/content/first-order-logic/completeness/identity.tex
+++ b/content/first-order-logic/completeness/identity.tex
@@ -40,13 +40,13 @@ The relation $\approx$ has the following properties:
 \item $\approx$ is symmetric.
 \item  $\approx$ is transitive.
 \item If $t \approx t'$, $f$ is !!a{function}, and $t_1$, \dots,
-  $t_{i-1}$, $t_{i+1}$, \dots, $t_n$ are terms, then
+  $t_{i-1}$, $t_{i+1}$, \dots, $t_n$ are closed terms, then
 \[
 \Atom{f}{t_1,\dots, t_{i-1}, t, t_{i+1}, \dots, t_n} \approx
 \Atom{f}{t_1,\dots, t_{i-1}, t', t_{i+1}, \dots, t_n}.
 \]
 \item If $t \approx t'$, $R$ is !!a{predicate}, and $t_1$, \dots,
-  $t_{i-1}$, $t_{i+1}$, \dots, $t_n$ are terms, then
+  $t_{i-1}$, $t_{i+1}$, \dots, $t_n$ are closed terms, then
 \begin{multline*}
 \Atom{R}{t_1,\dots, t_{i-1}, t, t_{i+1}, \dots, t_n} \in \Gamma^* \text{ iff } \\
 \Atom{R}{t_1,\dots, t_{i-1}, t', t_{i+1}, \dots, t_n} \in \Gamma^*.
@@ -59,7 +59,7 @@ Since $\Gamma^*$ is consistent and !!{complete}, $\eq[t][t'] \in
 \Gamma^*$ iff $\Gamma^* \Proves \eq[t][t']$.  Thus it is enough to
 show the following:
 \begin{enumerate}
-\item $\Gamma^* \Proves \eq[t][t]$ for all terms~$t$.
+\item $\Gamma^* \Proves \eq[t][t]$ for all closed terms~$t$.
 \item If $\Gamma^* \Proves \eq[t][t']$ then $\Gamma^* \Proves \eq[t'][t]$.
 \item If $\Gamma^* \Proves \eq[t][t']$ and $\Gamma^* \Proves
   \eq[t'][t'']$, then $\Gamma^* \Proves \eq[t][t'']$.
@@ -68,13 +68,13 @@ show the following:
 \Gamma^* \Proves
 \eq[\Atom{f}{t_1,\dots,t_{i-1},t,t_{i+1},,\dots,t_n}][\Atom{f}{t_1,\dots,t_{i-1},t',t_{i+1},\dots,t_n}]
 \]
-for every $n$-place !!{function}~$f$ and terms $t_1$, \dots,
+for every $n$-place !!{function}~$f$ and closed terms $t_1$, \dots,
 $t_{i-1}$, $t_{i+1}$, \dots,~$t_n$.
 \item If $\Gamma^* \Proves \eq[t][t']$ and
 $\Gamma^* \Proves
 \Atom{R}{t_1,\dots,t_{i-1},t,t_{i+1},\dots,t_n}$, then
 $\Gamma^* \Proves \Atom{R}{t_1,\dots,t_{i-1},t',t_{i+1},\dots,t_n}$
-for every $n$-place !!{predicate}~$R$ and terms $t_1$, \dots,
+for every $n$-place !!{predicate}~$R$ and closed terms $t_1$, \dots,
 $t_{i-1}$, $t_{i+1}$, \dots,~$t_n$.
 \end{enumerate}
 \end{proof}
@@ -85,8 +85,8 @@ Complete the proof of~\olref[fol][com][ide]{prop:approx-equiv}.
 
 \begin{defn}
 Suppose $\Gamma^*$ is a consistent and !!{complete} set in a
-language~$\Lang L$, $t$ is a term, and $\approx$ as in the previous
-definition.  Then:
+language~$\Lang L$, $t$ is a closed term, and $\approx$ as in the
+previous definition. Then:
 \[
 \equivrep{t}{\approx} = \Setabs{t'}{t'\in \Trm[L], t \approx t'}
 \]
@@ -134,8 +134,8 @@ If $t \approx t'$, then $\equivrep{t}{\approx} =
 
 \begin{prop}
 $\Struct{\equivclass{M}{\approx}}$ is well defined, i.e., if $t_1$,
-  \dots, $t_n$, $t_1'$, \dots, $t_n'$ are terms, and $t_i \approx
-  t_i'$ then
+  \dots, $t_n$, $t_1'$, \dots, $t_n'$ are closed terms,
+  and $t_i \approx t_i'$ then
 \begin{enumerate}
 \item $\equivrep{\Atom{f}{t_1,\dots, t_n}}{\approx} =
     \equivrep{\Atom{f}{t_1',\dots, t_n'}}{\approx}$, i.e.,

--- a/content/first-order-logic/models-theories/expressing-relations.tex
+++ b/content/first-order-logic/models-theories/expressing-relations.tex
@@ -17,7 +17,7 @@ relations in !!a{structure}~$\Struct M$ in terms of the primitives of
 the language~$\Lang L$ of~$\Struct M$.  By this we mean the following:
 the !!{domain} of $\Struct M$ is a set of objects.  The !!{constant}s,
 !!{function}s, and !!{predicate}s are interpreted in~$\Struct M$ by
-some objects in$\Domain M$, functions on~$\Domain M$, and relations
+some objects in~$\Domain M$, functions on~$\Domain M$, and relations
 on~$\Domain M$.  For instance, if $\Obj A^2_0$ is in $\Lang L$, then
 $\Struct M$ assigns to it a relation~$R = \Assign{{\Obj
   A^2_0}}{M}$. Then the formula $\Atom{\Obj A^2_0}{\Obj v_1, \Obj v_2}$

--- a/content/lambda-calculus/lambda-definability/introduction.tex
+++ b/content/lambda-calculus/lambda-definability/introduction.tex
@@ -39,7 +39,7 @@ The Church numeral $\num n$ is encoded as a lambda term which
 represents a function accepting two arguments $f$ and $x$, and
 returns $f^n(x)$. Church numerals are evidently in normal form.
 
-A represention of natural numbers in the lambda calculus is only
+A representation of natural numbers in the lambda calculus is only
 useful, of course, if we can compute with them.  Computing with Church
 numerals in the lambda calculus means applying a $\lambd$-term~$F$ to
 such a Church numeral, and reducing the combined term~$F\, \num n$ to
@@ -48,7 +48,7 @@ form is always a Church numeral~$\num m$, we can think of the output
 of the computation as being the number~$m$. We can then think of~$F$
 as defining a function $f\colon \Nat \to \Nat$, namely the function
 such that $f(n) = m$ iff $F\, \num n \red \num m$. Because of the
-Church-Rosser property, normal forms are unique if they exist. So if
+Church--Rosser property, normal forms are unique if they exist. So if
 $F\, \num n \red \num m$, there can be no other term in normal form,
 in particular no other Church numeral, that $F \, \num n$ reduces to.
 


### PR DESCRIPTION
Just for the avoidance of ambiguity, this commit replaces various uses of 'term' with 'closed term' when the latter is required.