### PR TITLE
Remove division symbol from infinitesimals example.

### DIFF
--- a/content/first-order-logic/completeness/compactness.tex
+++ b/content/first-order-logic/completeness/compactness.tex
@@ -123,25 +123,28 @@ model of~$\Gamma$, but is not covered, since $\Value{c}{M} \neq
 \begin{ex}
 Consider a language $\Lang{L}$ containing the !!{predicate}~$<$,
 !!{constant}s $\Obj{0}$, $\Obj{1}$, and !!{function}s $+$, $\times$,
-$-$, $\div$. Let $\Gamma$ be the set of all !!{sentence}s in this
-language true in $\Struct{Q}$ with domain $\Rat$ and the obvious
-interpretations.  $\Gamma$ is the set of all !!{sentence}s
-of~$\Lang{L}$ true about the rational numbers. Of course, in $\Rat$
-(and even in $\Real$), there are no numbers which are greater than~$0$
-but less than $1/k$ for all $k \in \PosInt$.  Such a number, if it
-existed, would be an \emph{infinitesimal:} non-zero, but infinitely
-small.  The compactness theorem shows that there are models
-of~$\Gamma$ in which infinitesimals exist: Let $\Delta$ be $\{0<c\}
-\cup \Setabs{c < (\Obj{1} \div \num{k})}{k \in \PosInt}$ (where
-$\num{k} = (\Obj{1} + (\Obj{1} + \dots + (\Obj{1} + \Obj{1})\dots))$
-with $k$ $\Obj{1}$'s). For any finite subset~$\Delta_0$ of~$\Delta$
-there is a $K$ such that all the !!{sentence}s $c < (\Obj{1} \div \num{k})$ in
-$\Delta_0$ have $k < K$. If we expand $\Struct{Q}$ to $\Struct{Q'}$
-with $\Assign{c}{Q'} = 1/K$ we have that $\Sat{Q'}{\Gamma \cup
-  \Delta_0}$, and so $\Gamma \cup \Delta$ is finitely satisfiable
-(Exercise: prove this in detail). By compactness, $\Gamma \cup \Delta$
-is satisfiable. Any model~$\Struct{S}$ of $\Gamma \cup \Delta$
-contains an infinitesimal, namely~$\Assign{c}{S}$.
+$-$. Let $\Gamma$ be the set of all !!{sentence}s in this language
+true in $\Struct{Q}$ with domain $\Rat$ and the obvious
+interpretations of the non-logical symbols.  $\Gamma$ is the set of
+all !!{sentence}s of~$\Lang{L}$ true about the rational numbers.
+Of course, in $\Rat$ (and even in $\Real$), there are no numbers
+which are greater than~$0$ but less than $1/k$ for all
+$k \in \PosInt$.  Such a number, if it existed, would be an
+\emph{infinitesimal:} non-zero, but infinitely small.  The
+compactness theorem shows that there are models of~$\Gamma$ in
+which infinitesimals exist: Let $\Delta$ be $\{ 0 < c \} \cup
+\Setabs{c < \Obj{1} / \num{k}}{k \in \PosInt}$, where
+$\num{k} = \Obj{1} + (\Obj{1} + \dots + (\Obj{1} + \Obj{1})\dots)$
+with $k$ $\Obj{1}$'s, and $c < \Obj{1} / \num{k}$ means
+$c \times \num{k} < \Obj{1}$. For any finite subset~$\Delta_0$
+of~$\Delta$ there is a $K$ such that all the !!{sentence}s
+$c < \Obj{1} / \num{k}$ in $\Delta_0$ have $k < K$. If we expand
+$\Struct{Q}$ to $\Struct{Q'}$ with $\Assign{c}{Q'} = 1/K$ we have that
+$\Sat{Q'}{\Gamma \cup \Delta_0}$, and so $\Gamma \cup \Delta$ is
+finitely satisfiable (Exercise: prove this in detail). By compactness,
+$\Gamma \cup \Delta$ is satisfiable. Any model~$\Struct{S}$ of
+$\Gamma \cup \Delta$ contains an infinitesimal,
+namely~$\Assign{c}{S}$.
 \end{ex}
 }{}
 


### PR DESCRIPTION
Since division is a partial function it shouldn't have a function symbol in the language of Q (i.e. the first-order language of ordered fields).

This commit removes the symbol from the signature but tries to retain the intuitive quality of the example as it currently stands.

This pull request is an alternative to [the one suggested by @greleigh](https://github.com/OpenLogicProject/OpenLogic/pull/346).