### PR TITLE
Fix some variable name mistakes in the PL formation sequences material

### DIFF
--- a/content/propositional-logic/syntax-and-semantics/formation-sequences.tex
+++ b/content/propositional-logic/syntax-and-semantics/formation-sequences.tex
@@ -107,6 +107,10 @@ for~$!A_n$, and that $k \leq n$. Then $\tuple{!A_0,\dotsc,!A_k}$
 is a formation sequence for~$!A_k$.
 \end{lem}
 
+\begin{proof}
+Exercise.
+\end{proof}
+
 \begin{thm}
 \ollabel{thm:fseq-frm-equiv}
 $\Frm[L_0]$ is the set of all expressions (strings of symbols)

--- a/content/propositional-logic/syntax-and-semantics/formation-sequences.tex
+++ b/content/propositional-logic/syntax-and-semantics/formation-sequences.tex
@@ -127,11 +127,11 @@ By the definition of a formation sequence, either $!A_n$ is
 atomic or there must exist $j,k < n$ such that one of the
 following is the case:
 \begin{enumerate}
-    \tagitem{prvNot}{$!A_i \ident \lnot !A_j$.}{}%
-    \tagitem{prvAnd}{$!A_i \ident (!A_j \land !A_k)$.}{}%
-    \tagitem{prvOr}{$!A_i \ident (!A_j \lor !A_k)$.}{}%
-    \tagitem{prvIf}{$!A_i \ident (!A_j \lif !A_k)$.}{}%
-    \tagitem{prvIff}{$!A_i \ident (!A_j \liff !A_k)$.}{}%
+    \tagitem{prvNot}{$!A_n \ident \lnot !A_j$.}{}%
+    \tagitem{prvAnd}{$!A_n \ident (!A_j \land !A_k)$.}{}%
+    \tagitem{prvOr}{$!A_n \ident (!A_j \lor !A_k)$.}{}%
+    \tagitem{prvIf}{$!A_n \ident (!A_j \lif !A_k)$.}{}%
+    \tagitem{prvIff}{$!A_n \ident (!A_j \liff !A_k)$.}{}%
 \end{enumerate}
 Now we reason by cases. If $!A_n$ is atomic then
 $!A_n \in \Frm[L_0]$. Suppose instead that $!A \equiv


### PR DESCRIPTION
What it says on the tin, plus making the initial formation sequences lemma an exercise for PL like it is for FOL.
