### PR TITLE
Fix intuitionistic equivalent of LEM

### DIFF
--- a/content/first-order-logic/beyond/intuitionistic-logic.tex
+++ b/content/first-order-logic/beyond/intuitionistic-logic.tex
@@ -117,7 +117,7 @@ this more precise.
 \begin{thm}
 Intuitionistically, the following axiom schemata are equivalent:
 \begin{enumerate}
-\item $(!A \lif \lfalse) \lif \lnot !A$.
+\item $(!A \lnot \lif \lfalse) \lif !A$.
 \item $!A \lor \lnot !A$
 \item $\lnot \lnot !A \lif !A$
 \end{enumerate}

--- a/content/first-order-logic/beyond/intuitionistic-logic.tex
+++ b/content/first-order-logic/beyond/intuitionistic-logic.tex
@@ -117,7 +117,7 @@ this more precise.
 \begin{thm}
 Intuitionistically, the following axiom schemata are equivalent:
 \begin{enumerate}
-\item $(!A \lnot \lif \lfalse) \lif !A$.
+\item $(\lnot !A \lif \lfalse) \lif !A$.
 \item $!A \lor \lnot !A$
 \item $\lnot \lnot !A \lif !A$
 \end{enumerate}


### PR DESCRIPTION
By the BHK interpretation, $\lnot \varphi$ is a shorthand for $\varphi \implies \perp$. The original statement was just the definition of negation in intuitionistic logic, not the LEM.