### PR TITLE
Change N to Z+ in definition of congruence

### DIFF
--- a/content/sets-functions-relations/relations/equivalence-relations.tex
+++ b/content/sets-functions-relations/relations/equivalence-relations.tex
@@ -62,7 +62,7 @@ that $\equivrep{x}{R} = \equivrep{y}{R}$. So $Rxy$.
 
 \begin{ex}
 A nice example of equivalence relations comes from modular arithmetic.
-For any $a$, $b$, and $n \in \Nat$, say that $a \equiv_n b$ iff
+For any $a$, $b$, and $n \in \PosInt$, say that $a \equiv_n b$ iff
 dividing $a$ by~$n$ gives the same remainder as dividing $b$ by~$n$.
 (Somewhat more symbolically: $a \equiv_n b$ iff, for some $k \in
 \Int$, $a - b = kn$.) Now, $\equiv_n$ is an equivalence relation, for
@@ -77,7 +77,7 @@ i.e.,~$\equivrep{n-1}{\equiv_n}$.
 
 \begin{prob}
 Show that $\equiv_n$ is an equivalence relation, for any $n \in
-\Nat$, and that $\equivclass{\Nat}{\equiv_n}$ has exactly $n$ members.
+\PosInt$, and that $\equivclass{\Nat}{\equiv_n}$ has exactly $n$ members.
 \end{prob}
 
 \end{document}


### PR DESCRIPTION
This fixes an issue in the congruence class example.

If we allow $n$ to be 0, then we have that $a \equiv_0 b$ iff for some $k \in \mathbb{Z}$, $a - b = k0$. But this happens iff $a - b = 0$, i.e. iff $a = b$. The congruence classes are then $\lbrace \lbrace 0 \rbrace , \lbrace 1 \rbrace , \lbrace 2 \rbrace , \dots \rbrace$ so that there are $|\mathbb{N}|$ equivalence classes when $n = 0$. Clearly the result that "there are exactly $n$ distinct equivalence classes generated by $\equiv_n$" fails in this case. The result holds if we restrict $n$ to $\mathbb{Z}^+$.