### PR TITLE
Fix spacing in `main-operator.tex`

### DIFF
--- a/content/first-order-logic/syntax-and-semantics/main-operator.tex
+++ b/content/first-order-logic/syntax-and-semantics/main-operator.tex
@@ -70,7 +70,7 @@ function.
 
 We call !!{formula}s by the names in \olref{tab:main-op} depending on
 which symbol their !!{main operator}
-is.\iftag{defNot,defOr,defAnd,defIf,defIff,defTrue,defFalse,defEx,defAll}
+is.{}\iftag{defNot,defOr,defAnd,defIf,defIff,defTrue,defFalse,defEx,defAll}
 {Recall, however, that defined operators do not officially appear in
 !!{formula}s. They are just abbreviations, so officially they cannot
 be the main operator of a formula. In proofs about all !!{formula}s


### PR DESCRIPTION
### Issue

Spacing between two particular sentences in `main-operator.tex` is incorrect.

<img width="546" alt="Screenshot 2024-02-05 at 11 28 24 AM" src="https://github.com/OpenLogicProject/OpenLogic/assets/66892505/d01d3b45-5b51-423b-bb74-0e2571e3b7a1">

### Fix

Added `{}` to indicate end of sentence (so `LaTeX` would apply proper sentence spacing).