### PR TITLE
Render `0` in math mode in `unique-readability.tex`

### DIFF
--- a/content/first-order-logic/syntax-and-semantics/unique-readability.tex
+++ b/content/first-order-logic/syntax-and-semantics/unique-readability.tex
@@ -74,10 +74,10 @@ number of left and right parentheses in a term~$t$.
 \end{prob}
 
 \begin{enumerate}
-\tagitem{prvFalse}{\indcase{!A}{\lfalse}{$\indfrm$ has 0 left and 0
+\tagitem{prvFalse}{\indcase{!A}{\lfalse}{$\indfrm$ has $0$ left and $0$
     right parentheses.}}{}
 
-\tagitem{prvTrue}{\indcase{!A}{\ltrue}{$\indfrm$ has 0 left and 0
+\tagitem{prvTrue}{\indcase{!A}{\ltrue}{$\indfrm$ has $0$ left and $0$
     right parentheses.}}{}
 
 \item \indcase{!A}{\Atom{R}{t_1,\dots,t_n}}{$l(\indfrm) = 1 + l(t_1) +


### PR DESCRIPTION
### Issue

Two particular $0$ appears to be in incorrect font.

<img width="441" alt="Screenshot 2024-02-05 at 11 40 31 AM" src="https://github.com/OpenLogicProject/OpenLogic/assets/66892505/ae5ce6f2-ed1a-4180-9d32-27f0ddbd27c7">

### Fix

Embeds two $0$ by $$ so they are rendered in math mode instead of text mode.