### PR TITLE
Fixed typo in important-sets.tex

### DIFF
--- a/content/sets-functions-relations/sets/important-sets.tex
+++ b/content/sets-functions-relations/sets/important-sets.tex
@@ -33,7 +33,7 @@ integer; every integer is a rational; and every rational is a real.
 Equally, it should be clear that $\Nat \subsetneq \Int \subsetneq
 \Rat$, since $-1$ is an integer but not a natural number, and
 $\nicefrac{1}{2}$ is rational but not integer. It is less obvious
-that $\Real \subsetneq \Rat$, i.e., that there are some real numbers
+that $\Rat \subsetneq \Real$, i.e., that there are some real numbers
 which are not rational\oliflabeldef{sfr:arith:real:realline}{, but we'll
 return to this in \olref[arith][real]{realline}}{}. 
 


### PR DESCRIPTION
There was a simple typo in the "Some Important Sets" section – all rationals are obviously reals, but the strict subset relation here is mistakenly written the other way around. It should be $\mathbb{Q} \subsetneq \mathbb{R}$.