### PR TITLE
Fix a typo, make usage of `!!a{formula}` more consistent, tweak presentation of formation sequences

### DIFF
--- a/content/first-order-logic/sequent-calculus/soundness.tex
+++ b/content/first-order-logic/sequent-calculus/soundness.tex
@@ -205,8 +205,8 @@ First, we consider the possible inferences with only one premise.
   \Sequent \Delta, !A \lif !B$.  Since
   \iftag{FOL}{$\Struct{M}$}{$\pAssign{v}$} was arbitrary, $\Gamma
   \Sequent \Delta, !A \lif !B$ is valid.  \iftag{FOL}{%
-\item The last inference is \LeftR{\lforall}: Then there is a
-  !!{formula}~$!A(x)$ and a closed term~$t$ such that $\pi$ ends in
+\item The last inference is \LeftR{\lforall}: Then there is
+  !!a{formula}~$!A(x)$ and a closed term~$t$ such that $\pi$ ends in
   \begin{prooftree}
     \AxiomC{}
     \Deduce$!A(t), \Gamma \fCenter \Delta$
@@ -225,8 +225,8 @@ First, we consider the possible inferences with only one premise.
   \Sequent \Delta$.  Since $\Struct M$ was arbitrary,
   $\lforall[x][!A(x)], \Gamma \Sequent \Delta$ is valid.
 \item The last inference is \RightR{\lexists}: Exercise.
-\item The last inference is \RightR{\lforall}: Then there is a
-  !!{formula}~$!A(x)$ and !!a{constant}~$a$ such that $\pi$ ends in
+\item The last inference is \RightR{\lforall}: Then there is
+  !!a{formula}~$!A(x)$ and !!a{constant}~$a$ such that $\pi$ ends in
   \begin{prooftree}
     \AxiomC{}
     \Deduce$\Gamma \fCenter \Delta, !A(a)$

--- a/content/first-order-logic/syntax-and-semantics/formation-sequences.tex
+++ b/content/first-order-logic/syntax-and-semantics/formation-sequences.tex
@@ -44,6 +44,8 @@ A finite sequence of $\Lang L$-strings $\tuple{t_0,\dotsc,t_n}$ is a
 $i \leq n$, either $t_i$ is !!a{variable} or !!a{constant}, or $\Lang
 L$ contains a $k$-ary !!{function}~$f$ and there exist
 $m_0,\dotsc,m_k < i$ such that $t_i \ident f(t_{m_0},\dotsc,t_{m_k})$.
+When it is necessary to distinguish, we will refer to formation
+sequences for terms as \emph{term formation sequences}.
 \end{defn}
 
 \begin{ex}
@@ -74,6 +76,8 @@ holds:
     \tagitem{prvAll}{$!A_i \ident \lforall[x][!A_j]$.}{}%
     \tagitem{prvEx}{$!A_i \ident \lexists[x][!A_j]$.}{}%
 \end{enumerate}
+When it is necessary to distinguish, we will refer to formation
+sequences for formulas as \emph{formula formation sequences}.
 \end{defn}
 
 \begin{ex}
@@ -165,8 +169,8 @@ Prove \olref[fol][syn][fseq]{lem:fseq-init}.
 
 \begin{thm}
 \ollabel{thm:fseq-frm-equiv}
-$\Frm[L]$ is the set of all expressions (strings of symbols)
-in the language~$\Lang L$ with a formation sequence.
+$\Frm[L]$ is the set of all $\Lang L$-strings $\varphi$ such that
+there exists a formula formation sequence for $\varphi$.
 \end{thm}
 
 \begin{proof}
@@ -210,8 +214,8 @@ for !!{formula}s.
 
 \begin{prop}
 \ollabel{prop:fseq-trm-equiv}
-$\Trm[L]$ is the set of all expressions~$t$ of~$\Lang L$
-such that there exists a formation sequence for~$t$.
+$\Trm[L]$ is the set of all $\Lang L$-strings $t$
+such that there exists a term formation sequence for~$t$.
 \end{prop}
 
 \begin{proof}
@@ -231,20 +235,20 @@ both by looking at minimal formation sequences.
 
 \begin{defn}[Minimal formation sequences]
 \ollabel{defn:minimal-fseq}
-A formation sequence $\tuple{!A_0, \ldots, !A_n}$ for~$!A$
-is a \emph{minimal formation sequence} for~$!A$
-if for every other formation sequence~$s$ for~$!A$, the length
-of~$s$ is greater than or equal to~$n+1$.
+A formation sequence $\tuple{!A_0, \ldots, !A_n}$ for a
+formula~$!A$ is a \emph{minimal formation sequence} for~$!A$
+if for every other formation sequence~$s$ for~$!A$,
+the length of~$s$ is greater than or equal to~$n+1$.
 
-Similarly, a term formation sequence $\tuple{t_0, \ldots, t_n}$
-for~$t$ is a \emph{minimal term formation sequence} for~$t$
-if for every other term formation sequence~$s$ for~$t$, the
-length of~$s$ is greater than or equal to~$n+1$.
+Similarly, a formation sequence $\tuple{t_0, \ldots, t_n}$
+for a term~$t$ is a \emph{minimal formation sequence}
+for~$t$ if for every other formation sequence~$s$ for~$t$,
+the length of~$s$ is greater than or equal to~$n+1$.
 \end{defn}
 
 Note that a formula or term can have more than one minimal
 formation sequence, but they will contain exactly the same
-expressions.
+strings.
 
 \begin{prop}
 \ollabel{prop:subformula-equivs}

--- a/content/first-order-logic/syntax-and-semantics/formation-sequences.tex
+++ b/content/first-order-logic/syntax-and-semantics/formation-sequences.tex
@@ -169,8 +169,8 @@ Prove \olref[fol][syn][fseq]{lem:fseq-init}.
 
 \begin{thm}
 \ollabel{thm:fseq-frm-equiv}
-$\Frm[L]$ is the set of all $\Lang L$-strings $\varphi$ such that
-there exists a formula formation sequence for $\varphi$.
+$\Frm[L]$ is the set of all $\Lang L$-strings~$!A$ such that
+there exists a formula formation sequence for~$!A$.
 \end{thm}
 
 \begin{proof}

--- a/content/first-order-logic/syntax-and-semantics/formation-sequences.tex
+++ b/content/first-order-logic/syntax-and-semantics/formation-sequences.tex
@@ -208,34 +208,10 @@ reasoning.
 Formation sequences for terms have similar properties to those
 for !!{formula}s.
 
-\begin{defn}[Formation sequences for terms]
-\ollabel{defn:fseq-trm}
-A finite sequence of $\Lang L$-strings $\tuple{t_0, \ldots, t_n}$
-is a \emph{term formation sequence} for~$t$ if $t \ident t_n$ and
-for all $i \leq n$,
-either $t_i$ is a !!{constant},
-or $t_i$ is a !!{variable},
-or there exist $j_1, \ldots, j_k < i$ such that
-$t_i \ident \Atom{f}{t_{j_1}, \ldots, t_{j_k}}$
-where $f$ is a $k$-place !!{function} of~$\Lang L$.
-\end{defn}
-
-\begin{ex}
-\[
-\tuple{
-    \Obj v_0,
-    \Obj c_1,
-    \Obj f^2_0({\Obj v_0}, {\Obj c_1})
-}
-\]
-is a formation sequence of
-$\Obj f^2_0({\Obj v_0}, {\Obj c_1})$.
-\end{ex}
-
 \begin{prop}
 \ollabel{prop:fseq-trm-equiv}
 $\Trm[L]$ is the set of all expressions~$t$ of~$\Lang L$
-such that there exists a term formation sequence for~$t$.
+such that there exists a formation sequence for~$t$.
 \end{prop}
 
 \begin{proof}

--- a/content/first-order-logic/syntax-and-semantics/formation-sequences.tex
+++ b/content/first-order-logic/syntax-and-semantics/formation-sequences.tex
@@ -208,10 +208,34 @@ reasoning.
 Formation sequences for terms have similar properties to those
 for !!{formula}s.
 
+\begin{defn}[Formation sequences for terms]
+\ollabel{defn:fseq-trm}
+A finite sequence of $\Lang L$-strings $\tuple{t_0, \ldots, t_n}$
+is a \emph{term formation sequence} for~$t$ if $t \ident t_n$ and
+for all $i \leq n$,
+either $t_i$ is a !!{constant},
+or $t_i$ is a !!{variable},
+or there exist $j_1, \ldots, j_k < i$ such that
+$t_i \ident \Atom{f}{t_{j_1}, \ldots, t_{j_k}}$
+where $f$ is a $k$-place !!{function} of~$\Lang L$.
+\end{defn}
+
+\begin{ex}
+\[
+\tuple{
+    \Obj v_0,
+    \Obj c_1,
+    \Obj f^2_0({\Obj v_0}, {\Obj c_1})
+}
+\]
+is a formation sequence of
+$\Obj f^2_0({\Obj v_0}, {\Obj c_1})$.
+\end{ex}
+
 \begin{prop}
 \ollabel{prop:fseq-trm-equiv}
-$\Trm[L]$ is the set of all expressions~$t$ in the language~$\Lang L$
-such that there exists a (term) formation sequence for~$t$.
+$\Trm[L]$ is the set of all expressions~$t$ of~$\Lang L$
+such that there exists a term formation sequence for~$t$.
 \end{prop}
 
 \begin{proof}
@@ -231,11 +255,20 @@ both by looking at minimal formation sequences.
 
 \begin{defn}[Minimal formation sequences]
 \ollabel{defn:minimal-fseq}
-A formation sequence $\tuple{!A_0,\dotsc,!A_n}$ for~$!A$ is a
-\emph{minimal formation sequence} for~$!A$
+A formation sequence $\tuple{!A_0, \ldots, !A_n}$ for~$!A$
+is a \emph{minimal formation sequence} for~$!A$
 if for every other formation sequence~$s$ for~$!A$, the length
 of~$s$ is greater than or equal to~$n+1$.
+
+Similarly, a term formation sequence $\tuple{t_0, \ldots, t_n}$
+for~$t$ is a \emph{minimal term formation sequence} for~$t$
+if for every other term formation sequence~$s$ for~$t$, the
+length of~$s$ is greater than or equal to~$n+1$.
 \end{defn}
+
+Note that a formula or term can have more than one minimal
+formation sequence, but they will contain exactly the same
+expressions.
 
 \begin{prop}
 \ollabel{prop:subformula-equivs}

--- a/content/first-order-logic/syntax-and-semantics/terms-formulas.tex
+++ b/content/first-order-logic/syntax-and-semantics/terms-formulas.tex
@@ -55,7 +55,7 @@ is defined inductively as follows:
   is an atomic !!{formula}.
 
 \tagitem{prvNot}{If $!A$ is !!a{formula}, then $\lnot !A$ is
-  !!{formula}.}{}
+  !!a{formula}.}{}
 
 \tagitem{prvAnd}{If $!A$ and $!B$ are !!{formula}s, then $(!A \land
   !B)$ is !!a{formula}.}{}

--- a/content/model-theory/interpolation/definability.tex
+++ b/content/model-theory/interpolation/definability.tex
@@ -34,8 +34,8 @@ explicitly defines it.
 \begin{defn}
 Suppose $\Lang{L}$ is !!a{language} not containing the
 !!{predicate}~$P$.  A set $\Sigma(P)$ of !!{sentence}s of $\Lang{L}
-\cup \{P\}$ \emph{explicitly defines}~$P$ if and only if there is a
-!!{formula}~$!C(x_1, \dots, x_n)$ of $\Lang{L}$ such that
+\cup \{P\}$ \emph{explicitly defines}~$P$ if and only if there is
+!!a{formula}~$!C(x_1, \dots, x_n)$ of $\Lang{L}$ such that
 \[
 \Sigma(P) \Entails \lforall[x_1][\dots
   \lforall[x_n][(\Atom{P}{x_1,\dots, x_n} \liff !C(x_1, \dots,

--- a/content/propositional-logic/syntax-and-semantics/formation-sequences.tex
+++ b/content/propositional-logic/syntax-and-semantics/formation-sequences.tex
@@ -113,15 +113,15 @@ Exercise.
 
 \begin{thm}
 \ollabel{thm:fseq-frm-equiv}
-$\Frm[L_0]$ is the set of all expressions (strings of symbols)
+$\Frm[L_0]$ is the set of all strings of symbols
 in the language~$\Lang L_0$ with a formation sequence.
 \end{thm}
 
 \begin{proof}
-Let $F$ be the set of all strings of symbols in the language~$\Lang
-L_0$ that have a formation sequence. We have seen in
-\olref[pl][syn][fseq]{prop:formed} that $\Frm[L_0] \subseteq F$, so
-now we prove the converse.
+Let $F$ be the set of all strings of symbols in the
+language~$\Lang L_0$ that have a formation sequence.
+We have seen in \olref[pl][syn][fseq]{prop:formed} that
+$\Frm[L_0] \subseteq F$, so now we prove the converse.
 
 Suppose $!A$ has a formation sequence $\tuple{!A_0,\dotsc,!A_n}$.
 We prove that $!A \in \Frm[L_0]$ by strong induction on~$n$.

--- a/content/propositional-logic/syntax-and-semantics/formulas.tex
+++ b/content/propositional-logic/syntax-and-semantics/formulas.tex
@@ -87,8 +87,8 @@ is defined inductively as follows:
 \item Every !!{propositional variable}~$\Obj p_i$ is an atomic
   !!{formula}.
 
-\tagitem{prvNot}{If $!A$ is !!a{formula}, then $\lnot !A$ is a
-  !!{formula}.}{}
+\tagitem{prvNot}{If $!A$ is !!a{formula}, then $\lnot !A$ is
+  !!a{formula}.}{}
 
 \tagitem{prvAnd}{If $!A$ and $!B$ are !!{formula}s, then $(!A \land
   !B)$ is !!a{formula}.}{}


### PR DESCRIPTION
Fixes a typo and expands the material on term formation sequences in first-order logic slightly.