### PR TITLE
Typo

### DIFF
--- a/content/first-order-logic/beyond/second-order-logic.tex
+++ b/content/first-order-logic/beyond/second-order-logic.tex
@@ -88,7 +88,7 @@ is a set of relations of arity~$k$). Of course, if comprehension is
 included in the !!{derivation} system, then we have the added requirement that
 there are enough relations in the ``second-order part'' to satisfy the
 comprehension axioms---otherwise the !!{derivation} system is not sound!{} One
-easy way to insure that there are enough relations around is to take
+easy way to ensure that there are enough relations around is to take
 the second-order part to consist of \emph{all} the relations on the
 first-order part. Such !!a{structure} is called \emph{full}, and, in a
 sense, is really the ``intended !!{structure}'' for the language. If


### PR DESCRIPTION
Although insure and ensure are almost synonymous, insure is usually used only in financial contexts.