### PR TITLE
A few small fixes for modal logic

### DIFF
--- a/content/counterfactuals/introduction/strict-conditional.tex
+++ b/content/counterfactuals/introduction/strict-conditional.tex
@@ -99,7 +99,7 @@ impossible.
 \begin{prob}
   Give proofs in \Log{S5} of:
   \begin{enumerate}
-    \item  $\Box \lnot !B \Entails !A \strictif !B$
+    \item  $\Box \lnot !A \Entails !A \strictif !B$
     \item $!A \strictif !B \Entails \Box(!A \strictif !B)$
     \item $\lnot(!A \strictif !B)  \Entails \Box\lnot(!A \strictif !B)$
   \end{enumerate}

--- a/content/counterfactuals/minimal-change-semantics/antecedent-strengthening.tex
+++ b/content/counterfactuals/minimal-change-semantics/antecedent-strengthening.tex
@@ -8,7 +8,7 @@
 
 \olfileid{cnt}{min}{agg}
 
-\olsection{Antecedent Strengthenng}
+\olsection{Antecedent Strengthening}
 
 ``Strengthening the antecedent'' refers to the
 inference $!A \lif !C \Entails (!A \land !B) \lif !C$.  It is valid

--- a/content/methods/proofs/inference-patterns.tex
+++ b/content/methods/proofs/inference-patterns.tex
@@ -145,7 +145,7 @@ assuming that an arbitrary object (``$x$'') has the property~$P$, and
 show (based only on definitions or what you are allowed to assume)
 that $x$ has the property~$Q$. Because you have not stipulated what
 $x$ is specifically, other that it has the property $P$, then you can
-assert that all every $P$ has the property~$Q$. In short, $x$ is a
+assert that everything with $P$ has the property~$Q$. In short, $x$ is a
 stand-in for \emph{all} things with property~$P$.
 
 \begin{prop}

--- a/content/normal-modal-logic/completeness/truth-lemma.tex
+++ b/content/normal-modal-logic/completeness/truth-lemma.tex
@@ -11,8 +11,8 @@
 \olsection{The Truth Lemma}
 
 The canonical model~$\mModel{M^\Sigma}$ is defined in such a way that
-$\mSat{M^\Sigma}{!A}[\Delta]$ iff $!A \in \Delta$. For propositional
-variables, the definition of $V^\Sigma$ yields this directly. We have
+$\mSat{M^\Sigma}{!A}[\Delta]$ iff $!A \in \Delta$. For !!{propositional
+variable}s, the definition of $V^\Sigma$ yields this directly. We have
 to verify that the equivalence holds for all !!{formula}s, however. We
 do this by induction. The inductive step involves proving the
 equivalence for !!{formula}s involving propositional operators (where

--- a/content/normal-modal-logic/filtrations/S5-decidable.tex
+++ b/content/normal-modal-logic/filtrations/S5-decidable.tex
@@ -19,7 +19,7 @@ the system or not).
 \end{thm}
 
 \begin{proof}
-  Let $!A$ be given, and suppose the propositional variables
+  Let $!A$ be given, and suppose the !!{propositional variable}s
   occurring in $!A$ are among $p_1$, \dots, $p_k$.  Since for each
   $n$ there are only finitely many models with $n$ worlds assigning a
   value to $p_1$, \dots, $p_k$, we can enumerate, \emph{in parallel}, all

--- a/content/normal-modal-logic/frame-definability/properties-accessibility.tex
+++ b/content/normal-modal-logic/frame-definability/properties-accessibility.tex
@@ -95,7 +95,7 @@ In the case of \Ax{T} and reflexive models, it is easy to give an
 example of a model in which \Ax{T} itself fails: let $W = \{w\}$ and
 $V(p) = \emptyset$. Then $R$ is not reflexive, but $\mSat{M}{\Box
   p}[w]$ and $\mSat/{M}{p}[w]$. But here we have just a single
-instance of \Ax{T} that fails in~$\mModel{M}$, other instances, e.g.,
+instance of \Ax{T} that fails in~$\mModel{M}$; other instances, e.g.,
 $\Box \lnot p \lif \lnot p$ are true. It is harder to give examples
 where \emph{every substitution instance} of~\Ax{T} is true
 in~$\mModel{M}$ and $\mModel{M}$ is not reflexive. But there are such

--- a/content/normal-modal-logic/syntax-and-semantics/language-modal-logic.tex
+++ b/content/normal-modal-logic/syntax-and-semantics/language-modal-logic.tex
@@ -36,7 +36,7 @@ The basic language of modal logic contains
 
 \tagitem{prvTrue}{$\ltrue$ is an atomic !!{formula}.}{}
 
-\item Every propositional variable $\Obj p_i$ is an (atomic) !!{formula}.
+\item Every !!{propositional variable} $\Obj p_i$ is an (atomic) !!{formula}.
 
 \tagitem{prvNot}{If $!A$ is !!a{formula}, then $\lnot !A$ is
   !!a{formula}.}{}

--- a/content/normal-modal-logic/syntax-and-semantics/modal-validity.tex
+++ b/content/normal-modal-logic/syntax-and-semantics/modal-validity.tex
@@ -61,9 +61,9 @@
 \begin{prob}
   Show that the following are valid:
   \begin{enumerate}
-  \item $\Entails \Box p \lif \Box (q \lif p)$;
-  \item $\Entails \Box \lnot \lfalse$;
-  \item $\Entails \Box p \lif (\Box q \lif \Box p)$.
+  \item $\Box p \lif \Box (q \lif p)$;
+  \item $\Box \lnot \lfalse$;
+  \item $\Box p \lif (\Box q \lif \Box p)$.
   \end{enumerate}
 \end{prob}
 

--- a/content/normal-modal-logic/syntax-and-semantics/schemas.tex
+++ b/content/normal-modal-logic/syntax-and-semantics/schemas.tex
@@ -18,8 +18,8 @@
   \SSubst{!C}{\subst{!D_1}{p_1}, \dots, \subst{!D_n}{p_n}} \right) }.
   \]
   The !!{formula}~$!C$ is called the \emph{characteristic} !!{formula} of
-  the schema, and it is unique up to a renaming of the propositional
-  variables. !!^a{formula}~$!A$ is an \emph{instance} of a schema if
+  the schema, and it is unique up to a renaming of the !!{propositional
+  variable}s. !!^a{formula}~$!A$ is an \emph{instance} of a schema if
   it is a member of the set.
 \end{defn}
 

--- a/content/normal-modal-logic/syntax-and-semantics/tautological-instances.tex
+++ b/content/normal-modal-logic/syntax-and-semantics/tautological-instances.tex
@@ -32,8 +32,8 @@ is valid.
 \end{defn}
 
 \begin{lem}\ollabel{lem:valid-taut}
-  Suppose $!A$ is a modal-free !!{formula} whose propositional
-  variables are $p_1$, \dots, $p_n$, and let $!D_1$, \dots,
+  Suppose $!A$ is a modal-free !!{formula} whose !!{propositional
+  variable}s are $p_1$, \dots, $p_n$, and let $!D_1$, \dots,
   $!D_n$ be modal !!{formula}s. Then for any assignment $\pAssign{v}$,
   any model $\mModel{M} = \tuple{W, R, V}$, and any $w \in W$ such
   that $\pAssign{v}(p_i) = \True$ if and only if $\mSat{M}{!D_i}[w]$ we have

--- a/content/normal-modal-logic/syntax-and-semantics/truth-at-w.tex
+++ b/content/normal-modal-logic/syntax-and-semantics/truth-at-w.tex
@@ -110,7 +110,7 @@ for any~$!A$.
   Let $\mModel{M} = \tuple{W, R, V}$ be a model, and suppose $w_1, w_2 \in
   W$ are such that:
   \begin{enumerate}
-  \item $w_1 \in V(p)$ if and only if $w_2 \in V(p)$; and
+  \item $w_1 \in V(p)$ if and only if $w_2 \in V(p)$ (for every !!{propositional variable} $p$); and
   \item for all $w \in W$: $Rw_1w$ if and only if $Rw_2w$.
   \end{enumerate}
   Using induction on !!{formula}s, show that for all !!{formula}s $!A$:

--- a/content/normal-modal-logic/syntax-and-semantics/truth-in-model.tex
+++ b/content/normal-modal-logic/syntax-and-semantics/truth-in-model.tex
@@ -1,5 +1,3 @@
-% Part: normal-modal-logic
-% Chapter: syntax-and-semantics
 % Section: truth-in-model
 
 \documentclass[../../../include/open-logic-section]{subfiles}
@@ -56,7 +54,7 @@ in a given model. Let's introduce a notation for this.
 
 \begin{prob}
   Consider the following model $\mModel{M}$ for the language
-  comprising $p_1$, $p_2$, $p_3$ as the only propositional variables:
+  comprising $p_1$, $p_2$, $p_3$ as the only !!{propositional variable}s:
   \begin{center}
     \begin{tikzpicture}[modal]
       \node[world] (w1) [label={[align=right]left:\mTrue{p_1}\\\mFalse{p_2}\\\mFalse{p_3}}]

--- a/content/propositional-logic/syntax-and-semantics/preliminaries.tex
+++ b/content/propositional-logic/syntax-and-semantics/preliminaries.tex
@@ -89,8 +89,8 @@ which is impossible by the inductive hypothesis.
 
 
 \begin{defn}[Uniform Substitution]
-If $!A$ and $!B$ are !!{formula}s, and $\Obj p_i$ is a propositional
-!!{variable}, then $\Subst{!A}{!B}{\Obj p_i}$ denotes the result of
+If $!A$ and $!B$ are !!{formula}s, and $\Obj p_i$ is a !!{propositional
+variable}, then $\Subst{!A}{!B}{\Obj p_i}$ denotes the result of
 replacing each occurrence of $\Obj p_i$ by an occurrence of $!B$ in $!A$;
 similarly, the simultaneous substitution of $\Obj p_1$, \dots,~$\Obj p_n$ by
 !!{formula}s $!B_1$, \dots,~$!B_n$ is denoted by

--- a/content/propositional-logic/syntax-and-semantics/semantic-notions.tex
+++ b/content/propositional-logic/syntax-and-semantics/semantic-notions.tex
@@ -18,7 +18,7 @@ We define the following semantic notions:
   some~$\pAssign{v}$, $\pSat{v}{!A}$; it is
   \emph{unsatisfiable} if for no $\pAssign{v}$, $\pSat{v}{!A}$;
 \item !!^a{formula}~$!A$ is a \emph{tautology} if $\pSat{v}{!A}$ for
-  all !!{valuation}s~$v$;
+  all !!{valuation}s~$\pAssign{v}$;
 \item !!^a{formula}~$!A$ is \emph{contingent} if it is satisfiable but
   not a tautology;
 \item If $\Gamma$ is a set of !!{formula}s, $\Gamma \Entails !A$ (``$\Gamma$

--- a/content/propositional-logic/syntax-and-semantics/valuations-sat.tex
+++ b/content/propositional-logic/syntax-and-semantics/valuations-sat.tex
@@ -132,8 +132,8 @@ Write down the truth table for this connective.
 
 \begin{thm}[Local Determination]
 \ollabel{thm:LocalDetermination} Suppose that $\pAssign{v_1}$ and
-$\pAssign{v_2}$ are !!{valuation}s that agree on the propositional
-letters occurring in $!A$, i.e., $\pAssign{v_1}(\Obj p_n) =
+$\pAssign{v_2}$ are !!{valuation}s that agree on the !!{propositional
+variable}s occurring in $!A$, i.e., $\pAssign{v_1}(\Obj p_n) =
 \pAssign{v_2}(\Obj p_n)$ whenever $\Obj p_n$ occurs in some
 !!{formula}~$!A$. Then $\pValue{v_1}$ and $\pValue{v_2}$ also agree
 on~$!A$, i.e., $\pValue{v_1}(!A) = \pValue{v_2}(!A)$.

--- a/content/sets-functions-relations/sets/basics.tex
+++ b/content/sets-functions-relations/sets/basics.tex
@@ -11,8 +11,8 @@
 
 A \emph{set} is a collection of objects, considered {as} a single
 object. The objects making up the set are called \emph{elements} or
-\emph{members} of the set. If $x$ is !!a{element} of a set~$a$, we
-write $x \in a$; if not, we write $x \notin a$. The set which has no
+\emph{members} of the set. If $x$ is !!a{element} of a set~$A$, we
+write $x \in A$; if not, we write $x \notin A$. The set which has no
 !!{element}s is called the \emph{empty} set and
 denoted~``$\emptyset$''.
 


### PR DESCRIPTION
A few typo/phrasing issues spotted while teaching modal logic from the text this spring term.