### PR TITLE
Fix error in problem about duals of characteristic modal logic axioms

### DIFF
--- a/content/normal-modal-logic/axioms-systems/duals.tex
+++ b/content/normal-modal-logic/axioms-systems/duals.tex
@@ -30,7 +30,7 @@ that sense.
 
 \begin{prop}\ollabel{prop:dualsys}
   For each !!{formula}~$!A$ in \olref[nml][prf][dua]{def:duals}:
-  $\Log{K}!A = \Log{K}! A_{\Diamond}$.
+  $\Log{K}!A = \Log{K}!A_{\Diamond}$.
 \end{prop}
 \begin{proof}
   Exercise.

--- a/content/normal-modal-logic/axioms-systems/duals.tex
+++ b/content/normal-modal-logic/axioms-systems/duals.tex
@@ -28,9 +28,15 @@ $\lnot\Box\lnot$ by $\Diamond$, and replacing $\lnot\Diamond\lnot$
 by~$\Box$. \Ax{D}, i.e., $\Box!A \lif \Diamond!A$ is its own dual in
 that sense.
 
+\begin{prop}\ollabel{prop:dualsys}
+  For each !!{formula}~$!A$ in \olref[nml][prf][dua]{def:duals}:
+  $\Log{K}!A = \Log{K}! A_{\Diamond}$.
+\end{prop}
+\begin{proof}
+  Exercise.
+\end{proof}
 \begin{prob}
-  Show that for each !!{formula}~$!A$ in \olref[nml][prf][dua]{def:duals}:
-  $\Log{K} \Proves !A \liff !A_\Diamond$.
+  Prove \olref[nml][prf][dua]{prop:dualsys}.
 \end{prob}
 
 \end{document}


### PR DESCRIPTION
There's a mistake in the original statement of the problem: the biconditionals are not derivable with just K (easy to verify with countermodels). What I take it the question is getting at is that each formula and its dual are "equivalent" in the sense that either can be taken as axiom and yield the same modal system. I've rephrased the problem that way.

I've also turned this from just a problem to a proposition (with proof as exercise). This seems better to me because the ability to infer the dual from the axiom is crucial to a lot of the example proofs of the next section.
