### PR TITLE
Fix minor typo in Alonzo Church's biography

### DIFF
--- a/content/history/biographies/alonzo-church.tex
+++ b/content/history/biographies/alonzo-church.tex
@@ -17,7 +17,7 @@ childhood, an air gun incident left Church blind in one eye. He
 finished preparatory school in Connecticut in 1920 and began his
 university education at Princeton that same year. He completed his
 doctoral studies in 1927. After a couple years abroad, Church returned
-to Princeton. Church was known exceedingly polite and careful. His
+to Princeton. Church was known to be exceedingly polite and careful. His
 blackboard writing was immaculate, and he would preserve important
 papers by carefully covering them in Duco cement (a clear
 glue). Outside of his academic pursuits, he enjoyed reading science


### PR DESCRIPTION
I think either "to be" or "as" is missing to make the sentence "Church was known exceedingly polite and careful." grammatically correct. I went with the former:

"Church was known exceedingly polite and careful." -> "Church was known to be exceedingly polite and careful."