### PR TITLE
Fix some typos in the variable assignments section

### DIFF
--- a/content/first-order-logic/syntax-and-semantics/assignments.tex
+++ b/content/first-order-logic/syntax-and-semantics/assignments.tex
@@ -42,14 +42,14 @@ and so $\Value{t}{M}[s_1] = s_1(x_i) = s_2(x_i) = \Value{t}{M}[s_2]$.
 For the inductive step, assume that $t = \Atom{f}{t_1, \dots, t_k}$
 and that the claim holds for $t_1$, \dots, $t_k$. Then
 \begin{align*}
-  \Value{t}{M}[s_1] & = \Value{\Atom{f}{t_1, \dots, t_k}}{M}[s_1] =\\
-  & = \Assign{f}{M}(\Value{t_1}{M}[s_1], \dots, \Value{t_k}{M}[s_1])
+  \Value{t}{M}[s_1] & = \Value{\Atom{f}{t_1, \dots, t_k}}{M}[s_1] \\
+  & = \Assign{f}{M}(\Value{t_1}{M}[s_1], \dots, \Value{t_k}{M}[s_1]).
 \intertext{For $j = 1$, \dots,~$k$, the !!{variable}s of~$t_j$ are
-    among $x_1$, \dots,~$x_n$. By induction hypothesis,
+    among $x_1$, \dots,~$x_n$. By the induction hypothesis,
     $\Value{t_j}{M}[s_1] = \Value{t_j}{M}[s_2]$. So,}
-\Value{t}{M}[s_1] & = \Value{\Atom{f}{t_1, \dots, t_k}}{M}[s_1] =\\
-  & = \Assign{f}{M}(\Value{t_1}{M}[s_1], \dots, \Value{t_k}{M}[s_1]) =\\
-  & = \Assign{f}{M}(\Value{t_1}{M}[s_2], \dots, \Value{t_k}{M}[s_2]) =\\
+\Value{t}{M}[s_1] & = \Value{\Atom{f}{t_1, \dots, t_k}}{M}[s_1] \\
+  & = \Assign{f}{M}(\Value{t_1}{M}[s_1], \dots, \Value{t_k}{M}[s_1]) \\
+  & = \Assign{f}{M}(\Value{t_1}{M}[s_2], \dots, \Value{t_k}{M}[s_2]) \\
   & = \Value{\Atom{f}{t_1, \dots, t_k}}{M}[s_2] = \Value{t}{M}[s_2].
 \end{align*}
 \end{proof}


### PR DESCRIPTION
There were some extra equality signs, a missing full stop, and a missing definite article.