### PR TITLE
Update recursion.tex

### DIFF
--- a/content/set-theory/spine/recursion.tex
+++ b/content/set-theory/spine/recursion.tex
@@ -37,7 +37,7 @@ $\delta \leq \alpha$.
 The empty function is trivially an $\emptyset$-approximation. 
 
 If $g$ is a $\gamma$-approximation, then $g \cup
-\{\tuple{\ordsucc{\gamma}, \tau(g)}\}$ is a $\ordsucc{\gamma}$-approximation.
+\{\tuple{\gamma, \tau(g)}\}$ is a $\ordsucc{\gamma}$-approximation.
 
 If $\gamma$ is a limit ordinal and $g_\delta$ is a $\delta$-approximation for all $\delta < \gamma$, let $g = \bigcup_{\delta \in \gamma} g_\delta$. This
 is a function, since our various $g_\delta$s agree on all values. And
@@ -126,5 +126,6 @@ Last, $\sigma(\alpha) = \xi(\funrestrictionto{\sigma}{\alpha}) = \theta(\ran{\fu
 \noindent
 Now, to vindicate \olref[valpha]{defValphas}, just take $A
 = \emptyset$ and $\tau(x) = \Pow{x}$ and $\theta(x) = \bigcup x$. At long last, this vindicates the definition of the $V_\alpha$s!{}
+
 
 \end{document}


### PR DESCRIPTION
Small typo fixed in proof of bounded recursion; to get a γ+ approximation, we add <γ, τ(g)>