### PR TITLE
Update cauchy.tex

### DIFF
--- a/content/sets-functions-relations/arithmetization/cauchy.tex
+++ b/content/sets-functions-relations/arithmetization/cauchy.tex
@@ -208,22 +208,23 @@ think that recursive definitions are ok.}
 	\end{cases}
 \end{align*}
 Both $f$ and $g$ are Cauchy sequences. (This can be checked fairly
-easily; but we leave it as an exercise.) Note that the function $(f-g)$
-tends to $0$, since the difference between $f$ and $g$ halves at every
+easily, but we leave it as an exercise.) Note that the function $(f-g)$
+tends to $0$, since the difference between $f$ and $g$ halves at each
 step. Hence $\equivrep{f}{} = \equivrep{g}{}$. 
 
-We will show that $(\forall h \in S)\equivrep{h}{} \leq \equivrep{f}{}$, invoking \olref{thm:cauchyorderedfield} as we go. Let $h \in S$ and
+We first show that $\equivrep{f}{}$ is an upper bound on $S$, i.e.\ that $(\forall h \in S)\equivrep{h}{} \leq \equivrep{f}{}$.  
+(We will invoke \olref{thm:cauchyorderedfield} as we go.) Let $h \in S$ and
 suppose, for reductio, that $\equivrep{f}{} < \equivrep{h}{}$, so that
 $0_\Real < \equivrep{(h-f)}{}$. Since $f$ is a monotonically
 decreasing Cauchy sequence, there is some $n \in \Nat$ such that
 $\equivrep{(c_{f(n)} - f)}{} < \equivrep{(h-f)}{}$. So:
 \[
-	(f(n))_\Real = \equivrep{c_{f(k)}}{} < \equivrep{f}{} + \equivrep{(h-f)}{} = \equivrep{h}{},
+	(f(n))_\Real = \equivrep{c_{f(n)}}{} < \equivrep{f}{} + \equivrep{(h-f)}{} = \equivrep{h}{},
 \]
-contradicting the fact that, by construction, $\equivrep{h}{} \leq (f(k))_\Real$.
+contradicting the fact that, by construction, $\equivrep{h}{} \leq (f(n))_\Real$.
 
-In an exactly similar way, we can show that $(\forall \equivrep{h} \in S)\equivrep{g}{} \leq \equivrep{h}{}$. So $\equivrep{f}{} = \equivrep{g}{}$ is the
-\emph{least} upper bound for $S$.
+We next show that $\equivrep{f}{} = \equivrep{g}{}$ is the \emph{least} upper bound on $S$. So let $j$ be any Cauchy sequence and suppose $\equivrep{j}{} < \equivrep{g}{}$. Reasoning as above (using the fact that $g$ is \emph{increasing}), there is $n \in \Nat$ such that $\equivrep{j}{} < (g(n))_\Real$. But by construction there is $h \in S$ such that $(g(n))_\Real \leq \equivrep{h}{}$, so $\equivrep{j}{} < \equivrep{h}{}$ and therefore $\equivrep{j}{}$ is not an upper bound on $S$.  
 \end{proof}
 
 \end{document}
+


### PR DESCRIPTION
Typo fixed in proof that [f] is an upper bound. Total stupidity fixed in proof that [g] = [f] is a least upper bound.