### PR TITLE
Fix typo in Cauchy sequence definition

### DIFF
--- a/content/sets-functions-relations/arithmetization/cauchy.tex
+++ b/content/sets-functions-relations/arithmetization/cauchy.tex
@@ -111,7 +111,7 @@ Cauchy sequences, and identify real numbers with equivalence
 relations. First we need the idea of a function which tends to $0$ in
 the limit. For any function $h : \Nat \to \Rat$, say that \emph{$h$
 tends to $0$} iff for any positive $\epsilon \in \Rat$ we have that
-$(\exists \ell \in \Nat)(\forall n > \ell)|f(n)| <
+$(\exists \ell \in \Nat)(\forall n > \ell)|h(n)| <
 \epsilon$.\footnote{Compare this with the definition of $\lim_{x
 \mathord{\rightarrow}\infty}f(x) = 0$ in
 \olref[his][set][limits]{sec}.} Further, where $f$ and $g$ are


### PR DESCRIPTION
Fixes #427.

## Summary

- Correct the definition of a function tending to 0 so the formula refers to the introduced function `h`.
- Replace `|f(n)|` with `|h(n)|` in `content/sets-functions-relations/arithmetization/cauchy.tex`.

## Validation

- `git diff --check`
- Verified the surrounding LaTeX source introduces `h : \Nat \to \Rat` immediately before the corrected formula.

Note: I did not run a PDF build locally because this machine does not have `latexmk` or `pdflatex` installed.
