### PR TITLE
fix `Example 58.7` typo

### DIFF
--- a/content/intuitionistic-logic/introduction/bhk-interpretation.tex
+++ b/content/intuitionistic-logic/introduction/bhk-interpretation.tex
@@ -133,7 +133,7 @@ construction of~$\lfalse$.  A construction of $!A \lor \lnot !A$ is a
 pair $\tuple{s, M}$ where either $s = 1$ and $M$ is a construction of
 $!A$, or $s = 2$ and $M$ is a construction of $\lnot !A$. Let $h_1$ be
 the function mapping a construction~$M_1$ of $!A$ to a construction of
-$!A \lor \lnot !A$: it maps $M_1$ to $\tuple{1, M_2}$. And let $h_2$
+$!A \lor \lnot !A$: it maps $M_1$ to $\tuple{1, M_1}$. And let $h_2$
 be the function mapping a construction~$M_2$ of $\lnot !A$ to a
 construction of $!A \lor \lnot !A$: it maps $M_2$ to $\tuple{2, M_2}$.
 


### PR DESCRIPTION
Fix typo in bhk interpretation for `Example 58.7`  