### PR TITLE
Fixed typo to Figure 5.2 in euclidean-filtrations.tex

### DIFF
--- a/content/normal-modal-logic/filtrations/euclidean-filtrations.tex
+++ b/content/normal-modal-logic/filtrations/euclidean-filtrations.tex
@@ -33,6 +33,7 @@ p$ is supposed to be true at~$w_2$, while $p$ is false at~$w_5$.
             label = {below: $\mSat{{}}{\Box p}$},
             right=of w1] {$w_2$}; 
     \draw[->] (w1) to (w2);
+    \draw[reflexive above] (w2) to (w2);  
     \node[world] (w3)
           [label={left: \mFalse{p}},
             label={below: $\mSat{{}}{\Box p}$},


### PR DESCRIPTION
<img width="609" height="360" alt="image" src="https://github.com/user-attachments/assets/fd257ebb-0f7a-4a6b-a3e3-2fc4111fff80" />
This is not serial (and even not euclidean) due to the nonexistence of the reflexive arrow at w2.